### PR TITLE
(NPUP-2) Implement Puppet functions in the parser.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,12 @@ Expression evaluator status:
 * [x] local scope
 * [x] node scope
 * [x] string interpolation
-* [ ] external data lookups (i.e. hiera)
+* [ ] custom functions written in Puppet (NYI: evaluation)
+* [ ] custom functions written in Ruby
+* [ ] custom types written in Puppet
+* [ ] custom types written in Ruby
+* [ ] external data binding (i.e. hiera)
+* [ ] module data functions (Ruby or Puppet)
 * [x] EPP support
 
 Type system implemented:

--- a/lib/include/puppet/compiler/ast/adapted.hpp
+++ b/lib/include/puppet/compiler/ast/adapted.hpp
@@ -304,6 +304,16 @@ BOOST_FUSION_ADAPT_STRUCT(
 )
 
 BOOST_FUSION_ADAPT_STRUCT(
+    puppet::compiler::ast::function_expression,
+    begin,
+    name,
+    parameters,
+    body,
+    end,
+    tree
+)
+
+BOOST_FUSION_ADAPT_STRUCT(
     puppet::compiler::ast::postfix_expression,
     primary,
     subexpressions

--- a/lib/include/puppet/compiler/ast/ast.hpp
+++ b/lib/include/puppet/compiler/ast/ast.hpp
@@ -41,6 +41,7 @@ namespace puppet { namespace compiler { namespace ast {
     struct node_expression;
     struct nested_query_expression;
     struct collector_expression;
+    struct function_expression;
     struct unary_expression;
     struct selector_expression;
     struct method_call_expression;
@@ -487,6 +488,7 @@ namespace puppet { namespace compiler { namespace ast {
         boost::spirit::x3::forward_ast<defined_type_expression>,
         boost::spirit::x3::forward_ast<node_expression>,
         boost::spirit::x3::forward_ast<collector_expression>,
+        boost::spirit::x3::forward_ast<function_expression>,
         boost::spirit::x3::forward_ast<unary_expression>,
         boost::spirit::x3::forward_ast<epp_render_expression>,
         boost::spirit::x3::forward_ast<epp_render_block>,
@@ -1979,6 +1981,35 @@ namespace puppet { namespace compiler { namespace ast {
      * @return Returns the given output stream.
      */
     std::ostream& operator<<(std::ostream& os, collector_expression const& node);
+
+    /**
+     * Represents an expression for defining a function in the Puppet language.
+     */
+    struct function_expression : context
+    {
+        /**
+         * Stores the function's name.
+         */
+        ast::name name;
+
+        /**
+         * Stores the function's parameters.
+         */
+        std::vector<parameter> parameters;
+
+        /**
+         * Stores the function's body.
+         */
+        std::vector<expression> body;
+    };
+
+    /**
+     * Stream insertion operator for function expression.
+     * @param os The output stream to write to.
+     * @param node The node to write.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, function_expression const& node);
 
     /**
      * Represents a unary operator.

--- a/lib/include/puppet/compiler/evaluation/evaluator.hpp
+++ b/lib/include/puppet/compiler/evaluation/evaluator.hpp
@@ -98,6 +98,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         runtime::values::value operator()(ast::defined_type_expression const& expression);
         runtime::values::value operator()(ast::node_expression const& expression);
         runtime::values::value operator()(ast::collector_expression const& expression);
+        runtime::values::value operator()(ast::function_expression const& expression);
         runtime::values::value operator()(ast::unary_expression const& expression);
         runtime::values::value operator()(ast::epp_render_expression const& expression);
         runtime::values::value operator()(ast::epp_render_block const& expression);

--- a/lib/include/puppet/compiler/parser/rules.hpp
+++ b/lib/include/puppet/compiler/parser/rules.hpp
@@ -85,6 +85,7 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(attribute_query_value,         "attribute value",               ast::primary_expression)
     DECLARE_RULE(binary_query_operation,        "binary query expression",       ast::binary_query_operation)
     DECLARE_RULE(binary_query_operator,         "binary query operator",         ast::binary_query_operator)
+    DECLARE_RULE(function_expression,           "function expression",           ast::function_expression)
     DECLARE_RULE(unary_expression,              "unary expression",              ast::unary_expression)
     DECLARE_RULE(unary_operator,                "unary operator",                ast::unary_operator)
     DECLARE_RULE(postfix_expression,            "postfix expression",            ast::postfix_expression)
@@ -404,6 +405,15 @@ namespace puppet { namespace compiler { namespace parser {
         (raw(lexer::token_id::keyword_or)  > boost::spirit::x3::attr(ast::binary_query_operator::logical_or))
     )
 
+    // Functions
+    DEFINE_RULE(
+        function_expression,
+        begin(lexer::token_id::keyword_function) >
+        name >
+        -(raw('(') > (raw(')', false) | parameters) > raw(')')) >
+        raw('{') > (raw('}', false) | statements) > end('}') > tree
+    )
+
     // Unary expressions
     DEFINE_RULE(
         unary_expression,
@@ -460,6 +470,7 @@ namespace puppet { namespace compiler { namespace parser {
         class_expression             |
         defined_type_expression      |
         node_expression              |
+        function_expression          |
         primary_expression
     )
     DEFINE_RULE(
@@ -636,6 +647,7 @@ namespace puppet { namespace compiler { namespace parser {
     );
 
     BOOST_SPIRIT_DEFINE(
+        function_expression,
         unary_expression,
         unary_operator,
         postfix_expression,

--- a/lib/include/puppet/compiler/scanner.hpp
+++ b/lib/include/puppet/compiler/scanner.hpp
@@ -62,6 +62,7 @@ namespace puppet { namespace compiler {
         void operator()(ast::nested_query_expression const& expression);
         void operator()(ast::primary_query_expression const& expression);
         void operator()(ast::attribute_query const& expression);
+        void operator()(ast::function_expression const& expression);
         void operator()(ast::unary_expression const& expression);
         void operator()(ast::postfix_expression const& expression);
         void operator()(ast::selector_expression const& expression);

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -494,6 +494,7 @@ namespace puppet { namespace compiler { namespace evaluation {
     value evaluator::operator()(node_expression const& expression)
     {
         // Node definition expressions are handled by the scanner; just return undef
+        // TODO: should this perhaps return [Resource[Node, hostname], Resource[Node, hostname], ...] for consistency?
         return values::undef();
     }
 
@@ -503,6 +504,16 @@ namespace puppet { namespace compiler { namespace evaluation {
         auto collector = make_shared<collectors::query_collector>(expression, _context.current_scope());
         _context.add(collector);
         return types::runtime(types::runtime::object_type(rvalue_cast(collector)));
+    }
+
+    value evaluator::operator()(function_expression const& expression)
+    {
+        // Not yet implemented for evaluation (TODO: uncomment the subsequence lines)
+        throw evaluation_exception("function expressions are not yet implemented.", expression);
+        // Function expressions are handled by the scanner
+        // TODO: it sure would be nice if functions and lambdas are represented in the type system so we can return
+        // references to them here, allowing for functional programming
+        // return values::undef();
     }
 
     value evaluator::operator()(unary_expression const& expression)

--- a/lib/src/compiler/scanner.cc
+++ b/lib/src/compiler/scanner.cc
@@ -434,6 +434,28 @@ namespace puppet { namespace compiler {
         operator()(expression.value);
     }
 
+    void scanner::operator()(ast::function_expression const& expression)
+    {
+        if (!can_define()) {
+            throw parse_exception("function definitions can only be defined at top-level or inside a class.", lexer::range(expression.begin, expression.end));
+        }
+
+        // TODO: register the function
+
+        // Functions have no class scope
+        class_scope scope(_scopes, {});
+
+        // Scan the parameters
+        for (auto const& parameter : expression.parameters) {
+            operator()(parameter);
+        }
+
+        // Scan the body
+        for (auto const& statement : expression.body) {
+            operator()(statement);
+        }
+    }
+
     void scanner::operator()(ast::unary_expression const& expression)
     {
         operator()(expression.operand);

--- a/lib/tests/fixtures/compiler/parser/good/functions.baseline
+++ b/lib/tests/fixtures/compiler/parser/good/functions.baseline
@@ -1,0 +1,383 @@
+statements:
+  - kind: function
+    begin:
+      offset: 0
+      line: 1
+    end:
+      offset: 16
+      line: 2
+    name:
+      kind: name
+      begin:
+        offset: 9
+        line: 1
+      end:
+        offset: 12
+        line: 1
+      value: foo
+  - kind: function
+    begin:
+      offset: 18
+      line: 4
+    end:
+      offset: 45
+      line: 6
+    name:
+      kind: name
+      begin:
+        offset: 27
+        line: 4
+      end:
+        offset: 40
+        line: 4
+      value: bar::baz::jam
+  - kind: function
+    begin:
+      offset: 47
+      line: 8
+    end:
+      offset: 64
+      line: 8
+    name:
+      kind: name
+      begin:
+        offset: 56
+        line: 8
+      end:
+        offset: 59
+        line: 8
+      value: baz
+  - kind: function
+    begin:
+      offset: 66
+      line: 10
+    end:
+      offset: 134
+      line: 14
+    name:
+      kind: name
+      begin:
+        offset: 75
+        line: 10
+      end:
+        offset: 78
+        line: 10
+      value: baz
+    parameters:
+      - variable:
+          kind: variable
+          begin:
+            offset: 79
+            line: 10
+          end:
+            offset: 83
+            line: 10
+          name: foo
+    body:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 91
+            line: 11
+          end:
+            offset: 95
+            line: 11
+          value: each
+        arguments:
+          - kind: variable
+            begin:
+              offset: 96
+              line: 11
+            end:
+              offset: 100
+              line: 11
+            name: foo
+        lambda:
+          begin:
+            offset: 102
+            line: 11
+          end:
+            offset: 132
+            line: 13
+          parameters:
+            - variable:
+                kind: variable
+                begin:
+                  offset: 103
+                  line: 11
+                end:
+                  offset: 105
+                  line: 11
+                name: x
+          body:
+            - kind: function call
+              function:
+                kind: name
+                begin:
+                  offset: 117
+                  line: 12
+                end:
+                  offset: 123
+                  line: 12
+                value: notice
+              arguments:
+                - kind: variable
+                  begin:
+                    offset: 124
+                    line: 12
+                  end:
+                    offset: 126
+                    line: 12
+                  name: x
+        end:
+          offset: 101
+          line: 11
+  - kind: function
+    begin:
+      offset: 136
+      line: 16
+    end:
+      offset: 165
+      line: 18
+    name:
+      kind: name
+      begin:
+        offset: 145
+        line: 16
+      end:
+        offset: 148
+        line: 16
+      value: baz
+    parameters:
+      - variable:
+          kind: variable
+          begin:
+            offset: 149
+            line: 16
+          end:
+            offset: 153
+            line: 16
+          name: foo
+      - variable:
+          kind: variable
+          begin:
+            offset: 155
+            line: 16
+          end:
+            offset: 159
+            line: 16
+          name: bar
+  - kind: function
+    begin:
+      offset: 167
+      line: 20
+    end:
+      offset: 285
+      line: 24
+    name:
+      kind: name
+      begin:
+        offset: 176
+        line: 20
+      end:
+        offset: 185
+        line: 20
+      value: something
+    parameters:
+      - type:
+          kind: type
+          begin:
+            offset: 186
+            line: 20
+          end:
+            offset: 193
+            line: 20
+          name: Integer
+        variable:
+          kind: variable
+          begin:
+            offset: 194
+            line: 20
+          end:
+            offset: 196
+            line: 20
+          name: x
+      - type:
+          kind: postfix
+          primary:
+            kind: type
+            begin:
+              offset: 198
+              line: 20
+            end:
+              offset: 204
+              line: 20
+            name: String
+          subexpressions:
+            - kind: access
+              begin:
+                offset: 204
+                line: 20
+              end:
+                offset: 210
+                line: 20
+              arguments:
+                - kind: number
+                  begin:
+                    offset: 205
+                    line: 20
+                  end:
+                    offset: 206
+                    line: 20
+                  base: decimal
+                  value: 0
+                - kind: number
+                  begin:
+                    offset: 208
+                    line: 20
+                  end:
+                    offset: 209
+                    line: 20
+                  base: decimal
+                  value: 1
+        variable:
+          kind: variable
+          begin:
+            offset: 211
+            line: 20
+          end:
+            offset: 213
+            line: 20
+          name: y
+        default_value:
+          kind: string
+          begin:
+            offset: 216
+            line: 20
+          end:
+            offset: 219
+            line: 20
+          value_range:
+            begin:
+              offset: 217
+              line: 20
+            end:
+              offset: 218
+              line: 20
+          value: X
+          escapes: \'
+          format: ""
+          margin: 0
+          quote: "'"
+          interpolated: false
+          remove_break: false
+      - captures:
+          offset: 221
+          line: 20
+        variable:
+          kind: variable
+          begin:
+            offset: 222
+            line: 20
+          end:
+            offset: 227
+            line: 20
+          name: rest
+    body:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 235
+            line: 21
+          end:
+            offset: 241
+            line: 21
+          value: notice
+        arguments:
+          - kind: name
+            begin:
+              offset: 242
+              line: 21
+            end:
+              offset: 244
+              line: 21
+            value: hi
+      - kind: binary
+        first:
+          kind: variable
+          begin:
+            offset: 249
+            line: 22
+          end:
+            offset: 253
+            line: 22
+          name: two
+        operations:
+          - operator_position:
+              offset: 254
+              line: 22
+            operator: =
+            operand:
+              kind: number
+              begin:
+                offset: 256
+                line: 22
+              end:
+                offset: 257
+                line: 22
+              base: decimal
+              value: 1
+          - operator_position:
+              offset: 258
+              line: 22
+            operator: +
+            operand:
+              kind: number
+              begin:
+                offset: 260
+                line: 22
+              end:
+                offset: 261
+                line: 22
+              base: decimal
+              value: 1
+      - kind: binary
+        first:
+          kind: variable
+          begin:
+            offset: 266
+            line: 23
+          end:
+            offset: 272
+            line: 23
+          name: three
+        operations:
+          - operator_position:
+              offset: 273
+              line: 23
+            operator: =
+            operand:
+              kind: variable
+              begin:
+                offset: 275
+                line: 23
+              end:
+                offset: 279
+                line: 23
+              name: two
+          - operator_position:
+              offset: 280
+              line: 23
+            operator: +
+            operand:
+              kind: number
+              begin:
+                offset: 282
+                line: 23
+              end:
+                offset: 283
+                line: 23
+              base: decimal
+              value: 1

--- a/lib/tests/fixtures/compiler/parser/good/functions.pp
+++ b/lib/tests/fixtures/compiler/parser/good/functions.pp
@@ -1,0 +1,24 @@
+function foo {
+}
+
+function bar::baz::jam {
+
+}
+
+function baz() {}
+
+function baz($foo) {
+    each($foo) |$x| {
+        notice $x
+    }
+}
+
+function baz($foo, $bar) {
+
+}
+
+function something(Integer $x, String[0, 1] $y = 'X', *$rest) {
+    notice hi
+    $two = 1 + 1
+    $three = $two + 1
+}


### PR DESCRIPTION
This commit implements Puppet functions in the parser.

Evaluation of function expressions are not yet implemented.  Compiling a
function expression will result in a "not yet implemented" error when
evaluating the resulting AST.