### PR TITLE
(NPUP-4) Implementing the `Callable` type and the relevant access operator for it.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Type system implemented:
 * [x] Any
 * [x] Array
 * [x] Boolean
-* [ ] Callable
+* [x] Callable
 * [x] CatalogEntry
 * [x] Collection
 * [x] Data

--- a/lib/include/puppet/compiler/evaluation/context.hpp
+++ b/lib/include/puppet/compiler/evaluation/context.hpp
@@ -261,6 +261,13 @@ namespace puppet { namespace compiler { namespace evaluation {
     struct context
     {
         /**
+         * Constructs a default evaluation context.
+         * Operations requiring node or catalog context will not be allowed.
+         * @param create_scope True to create a top scope or false to create no top scope; if there is no top scope, operations requiring scope access will not be permitted.
+         */
+        explicit context(bool create_scope = true);
+
+        /**
          * Constructs an evaluation context.
          * @param node The node being compiled.
          * @param catalog The catalog being compiled.
@@ -478,10 +485,13 @@ namespace puppet { namespace compiler { namespace evaluation {
 
         context(context&) = delete;
         context& operator=(context&) = delete;
+        void create_top_scope(std::shared_ptr<facts::provider> facts = nullptr);
         void evaluate_defined_types(size_t& index, std::vector<declared_defined_type*>& virtualized);
 
-        compiler::node& _node;
-        compiler::catalog& _catalog;
+        compiler::node* _node;
+        compiler::catalog* _catalog;
+        compiler::registry const* _registry;
+        evaluation::dispatcher const* _dispatcher;
         std::unordered_map<std::string, std::shared_ptr<evaluation::scope>> _scopes;
         std::vector<std::shared_ptr<scope>> _scope_stack;
         std::shared_ptr<scope> _node_scope;

--- a/lib/include/puppet/compiler/parser/parser.hpp
+++ b/lib/include/puppet/compiler/parser/parser.hpp
@@ -8,6 +8,7 @@
 #include "../lexer/lexer.hpp"
 #include "../module.hpp"
 #include <boost/iterator.hpp>
+#include <boost/optional.hpp>
 #include <string>
 #include <memory>
 
@@ -34,9 +35,16 @@ namespace puppet { namespace compiler { namespace parser {
     /**
      * Interpolates a string iterator range into a syntax tree.
      * @param range The range of the string to interpolate.
-     * @param moodule The module where the parsing is taking place.
+     * @param module The module where the parsing is taking place.
      * @return Returns the parsed syntax tree.
      */
     std::shared_ptr<ast::syntax_tree> interpolate(boost::iterator_range<lexer::lexer_string_iterator> range, compiler::module const* module = nullptr);
+
+    /**
+     * Parses a single postfix expression from a string.
+     * @param source The source to parse.
+     * @return Returns the postfix expression if parsed successfully or boost::none if not.
+     */
+    boost::optional<ast::postfix_expression> parse_postfix(std::string const& source);
 
 }}}  // namespace puppet::compiler::parser

--- a/lib/include/puppet/runtime/types/callable.hpp
+++ b/lib/include/puppet/runtime/types/callable.hpp
@@ -6,6 +6,9 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
+#include <vector>
+#include <memory>
+#include <limits>
 
 namespace puppet { namespace runtime { namespace types {
 
@@ -14,6 +17,76 @@ namespace puppet { namespace runtime { namespace types {
      */
     struct callable
     {
+        /**
+         * Constructs a Callable type.
+         * If neither min or max are specified, the arguments to the Callable must match the types.
+         * If min < types.size(), types with an index >= min are optional.
+         * If max > types.size(), the last type repeats until the max.
+         * If no types and no min/max are given, the Callable describes anything "callable" (i.e. Callable[0, default]).
+         * A Callable[0, 0] accepts no arguments.
+         * If no types are given and the min or max count are not 0, then the Callable describes the untyped arity and does not constrain the parameter types.
+         * @param types The parameter types of the callable.
+         * @param min The minimum number of parameters.
+         * @param max The maximum number of parameters.
+         * @param block_type The Callable representing a block parameter.
+         */
+        explicit callable(
+            std::vector<std::unique_ptr<values::type>> types = {},
+            int64_t min = 0,
+            int64_t max = std::numeric_limits<int64_t>::max(),
+            std::unique_ptr<values::type> block_type = nullptr
+         );
+
+        /**
+         * Copy constructor for callable type.
+         * @param other The other callable type to copy from.
+         */
+        callable(callable const& other);
+
+        /**
+         * Move constructor for callable type.
+         * Uses the default implementation.
+         */
+        callable(callable&&) noexcept = default;
+
+        /**
+         * Copy assignment operator for callable type.
+         * @param other The other callable type to copy assign from.
+         * @return Returns this callable type.
+         */
+        callable& operator=(callable const& other);
+
+        /**
+         * Move assignment operator for callable type.
+         * Uses the default implementation.
+         * @return Returns this callable type.
+         */
+        callable& operator=(callable&&) noexcept = default;
+
+        /**
+         * Gets the parameter types for the callable.
+         * @return Returns the parameter types for the callable.
+         */
+        std::vector<std::unique_ptr<values::type>> const& types() const;
+
+        /**
+         * Gets the minimum number of parameters for the callable.
+         * @return Returns the minimum number of parameters for the callable.
+         */
+        int64_t min() const;
+
+        /**
+         * Gets the maximum number of parameters for the callable.
+         * @return Returns the maximum number of parameters for the callable.
+         */
+        int64_t max() const;
+
+        /**
+         * Gets the block type parameter for the callable.
+         * @return Returns the block type parameter for the callable.
+         */
+        std::unique_ptr<values::type> const& block_type() const;
+
         /**
          * Gets the name of the type.
          * @return Returns the name of the type (i.e. Callable).
@@ -33,14 +106,21 @@ namespace puppet { namespace runtime { namespace types {
          * @return Returns true if the other type is a specialization or false if not.
          */
         bool is_specialization(values::type const& other) const;
+
+     private:
+        std::vector<std::unique_ptr<values::type>> _types;
+        int64_t _min;
+        int64_t _max;
+        std::unique_ptr<values::type> _block_type;
     };
 
     /**
      * Stream insertion operator for callable type.
      * @param os The output stream to write the type to.
+     * @param type The callable type to write.
      * @return Returns the given output stream.
      */
-    std::ostream& operator<<(std::ostream& os, callable const&);
+    std::ostream& operator<<(std::ostream& os, callable const& type);
 
     /**
      * Equality operator for callable.
@@ -48,7 +128,7 @@ namespace puppet { namespace runtime { namespace types {
      * @param right The right type to compare.
      * @return Returns true if the two types are equal or false if not.
      */
-    bool operator==(callable const&, callable const&);
+    bool operator==(callable const& left, callable const& right);
 
     /**
      * Inequality operator for callable.

--- a/lib/include/puppet/runtime/types/tuple.hpp
+++ b/lib/include/puppet/runtime/types/tuple.hpp
@@ -27,7 +27,7 @@ namespace puppet { namespace runtime { namespace types {
          */
         explicit tuple(
             std::vector<std::unique_ptr<values::type>> types = std::vector<std::unique_ptr<values::type>>(),
-            int64_t from = std::numeric_limits<int64_t>::min(),
+            int64_t from = 0,
             int64_t to = std::numeric_limits<int64_t>::max());
 
         /**

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -202,11 +202,10 @@ namespace puppet { namespace runtime { namespace values {
 
         /**
          * Creates a type from a Puppet type expression.
-         * @param context The current evaluation context.
          * @param expression The expression to parse for the type.
-         * @return Returns the type if the parse was successful or boost::none if the parsing failed.
+         * @return Returns the type if the parse was successful or boost::none if the string is not a valid type expression.
          */
-        static boost::optional<type> parse(compiler::evaluation::context& context, std::string const& expression);
+        static boost::optional<type> parse(std::string const& expression);
 
      private:
         type_variant _value;

--- a/lib/src/compiler/evaluation/functions/assert_type.cc
+++ b/lib/src/compiler/evaluation/functions/assert_type.cc
@@ -41,7 +41,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                 return rvalue_cast(second);
             }
         } else if (auto str = first.as<string>()) {
-            auto type = values::type::parse(context.context(), *str);
+            auto type = values::type::parse(*str);
             if (!type) {
                 throw evaluation_exception((boost::format("the expression '%1%' is not a valid type specification.") % *str).str(), context.argument_context(0));
             }

--- a/lib/src/compiler/evaluation/scope.cc
+++ b/lib/src/compiler/evaluation/scope.cc
@@ -10,7 +10,9 @@ namespace puppet { namespace compiler { namespace evaluation {
         _line(0)
     {
         if (context) {
-            _path = context->tree->shared_path();
+            if (context->tree) {
+                _path = context->tree->shared_path();
+            }
             _line = context->begin.line();
         }
     }

--- a/lib/src/compiler/parser/parser.cc
+++ b/lib/src/compiler/parser/parser.cc
@@ -156,4 +156,29 @@ namespace puppet { namespace compiler { namespace parser {
         return tree;
     }
 
+    boost::optional<ast::postfix_expression> parse_postfix(std::string const& source)
+    {
+        static string_static_lexer lexer;
+
+        try {
+            // Get lexer iterators
+            auto begin = lex_begin(source);
+            auto end = lex_end(source);
+
+            // Get the token iterators from the lexer
+            auto token_begin = lexer.begin(begin, end);
+            auto token_end = lexer.end();
+
+            // Parse the entire source into a single postfix expression
+            ast::postfix_expression result;
+            if (x3::parse(token_begin, token_end, x3::with<tree_context_tag>(nullptr)[parser::postfix_expression], result) &&
+                (token_begin == token_end || token_begin->id() == boost::lexer::npos)) {
+                return result;
+            }
+        } catch (lexer_exception<typename string_static_lexer::input_iterator_type> const& ex) {
+        } catch (x3::expectation_failure<typename string_static_lexer::iterator_type> const& ex) {
+        }
+        return boost::none;
+    }
+
 }}}  // namespace puppet::compiler::parser

--- a/lib/src/runtime/types/callable.cc
+++ b/lib/src/runtime/types/callable.cc
@@ -1,9 +1,61 @@
 #include <puppet/runtime/values/value.hpp>
+#include <puppet/cast.hpp>
 #include <boost/functional/hash.hpp>
 
 using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
+
+    callable::callable(vector<unique_ptr<values::type>> types, int64_t min, int64_t max, unique_ptr<values::type> block_type) :
+        _types(rvalue_cast(types)),
+        _min(min),
+        _max(max),
+        _block_type(rvalue_cast(block_type))
+    {
+    }
+
+    callable::callable(callable const& other) :
+        _min(other._min),
+        _max(other._max)
+    {
+        _types.reserve(other._types.size());
+        for (auto const& element : other._types) {
+            _types.emplace_back(new values::type(*element));
+        }
+        _block_type.reset(other._block_type ? new values::type{ *other._block_type } : nullptr);
+    }
+
+    callable& callable::operator=(callable const& other)
+    {
+        _types.reserve(other._types.size());
+        for (auto const& element : other._types) {
+            _types.emplace_back(new values::type(*element));
+        }
+        _min = other._min;
+        _max = other._max;
+        _block_type.reset(other._block_type ? new values::type{ *other._block_type } : nullptr);
+        return *this;
+    }
+
+    vector<unique_ptr<values::type>> const& callable::types() const
+    {
+        return _types;
+    }
+
+    int64_t callable::min() const
+    {
+        return _min;
+    }
+
+    int64_t callable::max() const
+    {
+        return _max;
+    }
+
+    unique_ptr<values::type> const& callable::block_type() const
+    {
+        return _block_type;
+    }
 
     char const* callable::name()
     {
@@ -12,26 +64,116 @@ namespace puppet { namespace runtime { namespace types {
 
     bool callable::is_instance(values::value const& value) const
     {
-        // TODO: implement
+        // Currently functions cannot be represented as a value,
+        // This will need to change once functions can be properly treated as a value.
         return false;
     }
 
     bool callable::is_specialization(values::type const& other) const
     {
-        // No specializations for Callable
-        return false;
+        // Check for another Callable
+        auto ptr = boost::get<callable>(&other);
+        if (!ptr) {
+            return false;
+        }
+
+        // Check for less types (i.e. this type is more specialized)
+        auto& other_types = ptr->types();
+        if (other_types.size() < _types.size()) {
+            return false;
+        }
+        // All types must match
+        for (size_t i = 0; i < _types.size(); ++i) {
+            if (*_types[i] != *other_types[i]) {
+                return false;
+            }
+        }
+
+        // The blocks must match
+        if ((_block_type && !ptr->block_type()) ||
+            (!_block_type && ptr->block_type()) ||
+            *_block_type != *ptr->block_type()) {
+            return false;
+        }
+
+        // Check for equality
+        if (_min == ptr->min() && _max == ptr->max()) {
+            return false;
+        }
+        // Check for a more specialized min/max
+        return std::min(ptr->min(), ptr->max()) >= std::min(_min, _max) &&
+               std::max(ptr->min(), ptr->max()) <= std::max(_min, _max);
     }
 
-    ostream& operator<<(ostream& os, callable const&)
+    ostream& operator<<(ostream& os, callable const& type)
     {
+        // If no types, and the remaining parameters are all their default values, only output the type name
         os << callable::name();
-        // TODO: implement
+        if (type.types().empty() && type.min() == 0 && type.max() == numeric_limits<int64_t>::max() && !type.block_type()) {
+            return os ;
+        }
+
+        os << "[";
+        bool first = true;
+        for (auto const& element : type.types()) {
+            if (first) {
+                first = false;
+            } else {
+                os << ", ";
+            }
+            os << *element;
+        }
+        // If the min and max are equal to the number of types and there is no block, don't output the remaining parameters
+        int64_t size = static_cast<int64_t>(type.types().size());
+        if (type.min() == size && type.max() == size && !type.block_type()) {
+            os << ']';
+            return os;
+        }
+        if (size > 0) {
+            os << ", ";
+        }
+        if (type.min() == 0) {
+            os << "default";
+        } else {
+            os << type.min();
+        }
+        os << ", ";
+        if (type.max() == numeric_limits<int64_t>::max()) {
+            os << "default";
+        } else {
+            os << type.max();
+        }
+        if (type.block_type()) {
+            os << ", ";
+            os << *type.block_type();
+        }
+        os << ']';
         return os;
     }
 
-    bool operator==(callable const&, callable const&)
+    bool operator==(callable const& left, callable const& right)
     {
-        // TODO: implement
+        auto const& left_types = left.types();
+        auto const& right_types = right.types();
+
+        // Check for mismatch min, max, or type sizes
+        if (left.min() != right.min() ||
+            left.max() != right.max() ||
+            left_types.size() != right_types.size()) {
+            return false;
+        }
+        // Check the types
+        for (size_t i = 0; i < left_types.size(); ++i) {
+            if (*left_types[i] != *right_types[i]) {
+                return false;
+            }
+        }
+        // Check the block
+        if ((left.block_type() && !right.block_type()) ||
+            (!left.block_type() && right.block_type()) ||
+            *left.block_type() != *right.block_type()) {
+            return false;
+        }
         return true;
     }
 
@@ -46,6 +188,12 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
+        boost::hash_range(seed, type.types().begin(), type.types().end());
+        boost::hash_combine(seed, type.min());
+        boost::hash_combine(seed, type.max());
+        if (type.block_type()) {
+            boost::hash_combine(seed, *type.block_type());
+        }
         return seed;
     }
 

--- a/lib/src/runtime/types/struct.cc
+++ b/lib/src/runtime/types/struct.cc
@@ -205,10 +205,7 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        for (auto const& kvp : type.schema()) {
-            boost::hash_combine(seed, *kvp.first);
-            boost::hash_combine(seed, *kvp.second);
-        }
+        boost::hash_range(seed, type.schema().begin(), type.schema().end());
         return seed;
     }
 

--- a/lib/src/runtime/types/tuple.cc
+++ b/lib/src/runtime/types/tuple.cc
@@ -131,8 +131,9 @@ namespace puppet { namespace runtime { namespace types {
 
     ostream& operator<<(ostream& os, tuple const& type)
     {
+        // Only output the tuple name if everything is default
         os << tuple::name();
-        if (type.types().empty()) {
+        if (type.types().empty() && type.from() == 0 && type.to() == std::numeric_limits<int64_t>::max()) {
             return os;
         }
         os << '[';
@@ -145,14 +146,16 @@ namespace puppet { namespace runtime { namespace types {
             }
             os << *element;
         }
-        // If the from, to, and size of the types are equal, only output the types
+        // If the from and to are equal to the size of the types, only output the types
         int64_t size = static_cast<int64_t>(type.types().size());
         if (type.from() == size && type.to() == size) {
             os << ']';
             return os;
         }
-        os << ", ";
-        if (type.from() == std::numeric_limits<int64_t>::min()) {
+        if (size > 0) {
+            os << ", ";
+        }
+        if (type.from() == 0) {
             os << "default";
         } else {
             os << type.from();

--- a/lib/src/runtime/types/tuple.cc
+++ b/lib/src/runtime/types/tuple.cc
@@ -197,9 +197,7 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        for (auto const& element : type.types()) {
-            boost::hash_combine(seed, *element);
-        }
+        boost::hash_range(seed, type.types().begin(), type.types().end());
         boost::hash_combine(seed, type.from());
         boost::hash_combine(seed, type.to());
         return seed;

--- a/lib/src/runtime/types/variant.cc
+++ b/lib/src/runtime/types/variant.cc
@@ -127,9 +127,7 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        for (auto const& element : type.types()) {
-            boost::hash_combine(seed, *element);
-        }
+        boost::hash_range(seed, type.types().begin(), type.types().end());
         return seed;
     }
 

--- a/lib/tests/fixtures/compiler/parser/good/sample.baseline
+++ b/lib/tests/fixtures/compiler/parser/good/sample.baseline
@@ -1249,3 +1249,267 @@ statements:
         end:
           offset: 1076
           line: 79
+  - kind: function call
+    function:
+      kind: name
+      begin:
+        offset: 1080
+        line: 82
+      end:
+        offset: 1086
+        line: 82
+      value: notice
+    arguments:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 1087
+            line: 82
+          end:
+            offset: 1098
+            line: 82
+          value: assert_type
+        arguments:
+          - kind: postfix
+            primary:
+              kind: type
+              begin:
+                offset: 1099
+                line: 82
+              end:
+                offset: 1106
+                line: 82
+              name: Integer
+            subexpressions:
+              - kind: access
+                begin:
+                  offset: 1106
+                  line: 82
+                end:
+                  offset: 1109
+                  line: 82
+                arguments:
+                  - kind: number
+                    begin:
+                      offset: 1107
+                      line: 82
+                    end:
+                      offset: 1108
+                      line: 82
+                    base: decimal
+                    value: 0
+          - kind: number
+            begin:
+              offset: 1111
+              line: 82
+            end:
+              offset: 1112
+              line: 82
+            base: decimal
+            value: 1
+        end:
+          offset: 1113
+          line: 82
+  - kind: function call
+    function:
+      kind: name
+      begin:
+        offset: 1114
+        line: 83
+      end:
+        offset: 1120
+        line: 83
+      value: notice
+    arguments:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 1121
+            line: 83
+          end:
+            offset: 1132
+            line: 83
+          value: assert_type
+        arguments:
+          - kind: string
+            begin:
+              offset: 1133
+              line: 83
+            end:
+              offset: 1145
+              line: 83
+            value_range:
+              begin:
+                offset: 1134
+                line: 83
+              end:
+                offset: 1144
+                line: 83
+            value: Integer[1]
+            escapes: \'
+            format: ""
+            margin: 0
+            quote: "'"
+            interpolated: false
+            remove_break: false
+          - kind: number
+            begin:
+              offset: 1147
+              line: 83
+            end:
+              offset: 1148
+              line: 83
+            base: decimal
+            value: 1
+        end:
+          offset: 1149
+          line: 83
+  - kind: function call
+    function:
+      kind: name
+      begin:
+        offset: 1150
+        line: 84
+      end:
+        offset: 1156
+        line: 84
+      value: notice
+    arguments:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 1157
+            line: 84
+          end:
+            offset: 1168
+            line: 84
+          value: assert_type
+        arguments:
+          - kind: string
+            begin:
+              offset: 1169
+              line: 84
+            end:
+              offset: 1183
+              line: 84
+            value_range:
+              begin:
+                offset: 1170
+                line: 84
+              end:
+                offset: 1182
+                line: 84
+            value: String[4, 4]
+            escapes: \'
+            format: ""
+            margin: 0
+            quote: "'"
+            interpolated: false
+            remove_break: false
+          - kind: string
+            begin:
+              offset: 1185
+              line: 84
+            end:
+              offset: 1190
+              line: 84
+            value_range:
+              begin:
+                offset: 1186
+                line: 84
+              end:
+                offset: 1189
+                line: 84
+            value: foo
+            escapes: \'
+            format: ""
+            margin: 0
+            quote: "'"
+            interpolated: false
+            remove_break: false
+        lambda:
+          begin:
+            offset: 1192
+            line: 84
+          end:
+            offset: 1281
+            line: 87
+          parameters:
+            - variable:
+                kind: variable
+                begin:
+                  offset: 1193
+                  line: 84
+                end:
+                  offset: 1202
+                  line: 84
+                name: expected
+            - variable:
+                kind: variable
+                begin:
+                  offset: 1204
+                  line: 84
+                end:
+                  offset: 1211
+                  line: 84
+                name: actual
+          body:
+            - kind: function call
+              function:
+                kind: name
+                begin:
+                  offset: 1219
+                  line: 85
+                end:
+                  offset: 1226
+                  line: 85
+                value: warning
+              arguments:
+                - kind: string
+                  begin:
+                    offset: 1227
+                    line: 85
+                  end:
+                    offset: 1269
+                    line: 85
+                  value_range:
+                    begin:
+                      offset: 1228
+                      line: 85
+                    end:
+                      offset: 1268
+                      line: 85
+                  value: expected $expected but was given $actual
+                  escapes: \"'nrtsu$
+                  format: ""
+                  margin: 0
+                  quote: "\""
+                  interpolated: true
+                  remove_break: false
+            - kind: string
+              begin:
+                offset: 1274
+                line: 86
+              end:
+                offset: 1279
+                line: 86
+              value_range:
+                begin:
+                  offset: 1275
+                  line: 86
+                end:
+                  offset: 1278
+                  line: 86
+              value: bar
+              escapes: \'
+              format: ""
+              margin: 0
+              quote: "'"
+              interpolated: false
+              remove_break: false
+        end:
+          offset: 1191
+          line: 84

--- a/lib/tests/fixtures/compiler/parser/good/sample.pp
+++ b/lib/tests/fixtures/compiler/parser/good/sample.pp
@@ -78,3 +78,10 @@ case $name {
         wrong.fail
     }
 }
+
+notice assert_type(Integer[0], 1)
+notice assert_type('Integer[1]', 1)
+notice assert_type('String[4, 4]', 'foo') |$expected, $actual| {
+    warning "expected $expected but was given $actual"
+    'bar'
+}


### PR DESCRIPTION
Implementing the `Callable` type and the relevant access operator for it.

The syntax for the `Callable` type is:

`Callable[Arg1Type, Arg2Type, ..., ArgNType, min, max, BlockType]`

This does not yet include the work to support return types in `Callable` signatures as the design has not yet been finalized.  This gets to current parity with the Ruby implementation.