### PR TITLE
(NPUP-13) Allow class & defined type parameters to reference earlier ones.

### DIFF
--- a/lib/include/puppet/compiler/attribute.hpp
+++ b/lib/include/puppet/compiler/attribute.hpp
@@ -53,6 +53,12 @@ namespace puppet { namespace compiler {
          * Gets the attribute's shared value.
          * @return Returns the attribute's shared value.
          */
+        std::shared_ptr<runtime::values::value> shared_value();
+
+        /**
+         * Gets the attribute's shared value.
+         * @return Returns the attribute's shared value.
+         */
         std::shared_ptr<runtime::values::value const> shared_value() const;
 
         /**

--- a/lib/src/compiler/attribute.cc
+++ b/lib/src/compiler/attribute.cc
@@ -42,6 +42,11 @@ namespace puppet { namespace compiler {
         return *_value;
     }
 
+    shared_ptr<values::value> attribute::shared_value()
+    {
+        return _value;
+    }
+
     shared_ptr<values::value const> attribute::shared_value() const
     {
         return _value;

--- a/lib/src/compiler/resource.cc
+++ b/lib/src/compiler/resource.cc
@@ -194,7 +194,7 @@ namespace puppet { namespace compiler {
 
     bool resource::is_metaparameter(string const& name)
     {
-        static const unordered_set<string> metaparameters = {
+        static const vector<string> metaparameters = {
             "alias",
             "audit",
             "before",
@@ -207,7 +207,7 @@ namespace puppet { namespace compiler {
             "subscribe",
             "tag"
         };
-        return metaparameters.count(name) > 0;
+        return find(metaparameters.begin(), metaparameters.end(), name) != metaparameters.end();
     }
 
     resource::resource(types::resource type, resource const* container, boost::optional<ast::context> context, bool exported) :

--- a/lib/tests/fixtures/compiler/parser/good/sample.baseline
+++ b/lib/tests/fixtures/compiler/parser/good/sample.baseline
@@ -5875,3 +5875,302 @@ statements:
     end:
       offset: 3712
       line: 245
+  - kind: class
+    begin:
+      offset: 3948
+      line: 260
+    end:
+      offset: 4008
+      line: 261
+    name:
+      kind: name
+      begin:
+        offset: 3954
+        line: 260
+      end:
+        offset: 3969
+        line: 260
+      value: class_ref_param
+    parameters:
+      - variable:
+          kind: variable
+          begin:
+            offset: 3970
+            line: 260
+          end:
+            offset: 3977
+            line: 260
+          name: param1
+      - variable:
+          kind: variable
+          begin:
+            offset: 3979
+            line: 260
+          end:
+            offset: 3986
+            line: 260
+          name: param2
+        default_value:
+          kind: string
+          begin:
+            offset: 3989
+            line: 260
+          end:
+            offset: 4003
+            line: 260
+          value_range:
+            begin:
+              offset: 3990
+              line: 260
+            end:
+              offset: 4002
+              line: 260
+          value: ${param1}bar
+          escapes: \"'nrtsu$
+          format: ""
+          margin: 0
+          quote: "\""
+          interpolated: true
+          remove_break: false
+  - kind: resource
+    begin:
+      offset: 4010
+      line: 263
+    end:
+      offset: 4054
+      line: 265
+    status: realized
+    type:
+      kind: name
+      begin:
+        offset: 4010
+        line: 263
+      end:
+        offset: 4015
+        line: 263
+      value: class
+    bodies:
+      - title:
+          kind: name
+          begin:
+            offset: 4018
+            line: 263
+          end:
+            offset: 4033
+            line: 263
+          value: class_ref_param
+        operations:
+          - name:
+              kind: name
+              begin:
+                offset: 4039
+                line: 264
+              end:
+                offset: 4045
+                line: 264
+              value: param1
+            operator_position:
+              offset: 4046
+              line: 264
+            operator: =>
+            value:
+              kind: name
+              begin:
+                offset: 4049
+                line: 264
+              end:
+                offset: 4052
+                line: 264
+              value: foo
+  - kind: unless
+    begin:
+      offset: 4056
+      line: 267
+    end:
+      offset: 4122
+      line: 269
+    conditional:
+      kind: binary
+      first:
+        kind: variable
+        begin:
+          offset: 4063
+          line: 267
+        end:
+          offset: 4087
+          line: 267
+        name: class_ref_param::param2
+      operations:
+        - operator_position:
+            offset: 4088
+            line: 267
+          operator: ==
+          operand:
+            kind: string
+            begin:
+              offset: 4091
+              line: 267
+            end:
+              offset: 4099
+              line: 267
+            value_range:
+              begin:
+                offset: 4092
+                line: 267
+              end:
+                offset: 4098
+                line: 267
+            value: foobar
+            escapes: \'
+            format: ""
+            margin: 0
+            quote: "'"
+            interpolated: false
+            remove_break: false
+    body:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 4106
+            line: 268
+          end:
+            offset: 4110
+            line: 268
+          value: fail
+        arguments:
+          - kind: name
+            begin:
+              offset: 4111
+              line: 268
+            end:
+              offset: 4120
+              line: 268
+            value: incorrect
+  - kind: defined type
+    begin:
+      offset: 4124
+      line: 271
+    end:
+      offset: 4201
+      line: 273
+    name:
+      kind: name
+      begin:
+        offset: 4131
+        line: 271
+      end:
+        offset: 4143
+        line: 271
+      value: dt_ref_param
+    parameters:
+      - variable:
+          kind: variable
+          begin:
+            offset: 4144
+            line: 271
+          end:
+            offset: 4151
+            line: 271
+          name: param1
+      - variable:
+          kind: variable
+          begin:
+            offset: 4153
+            line: 271
+          end:
+            offset: 4160
+            line: 271
+          name: param2
+        default_value:
+          kind: string
+          begin:
+            offset: 4163
+            line: 271
+          end:
+            offset: 4177
+            line: 271
+          value_range:
+            begin:
+              offset: 4164
+              line: 271
+            end:
+              offset: 4176
+              line: 271
+          value: ${param1}bar
+          escapes: \"'nrtsu$
+          format: ""
+          margin: 0
+          quote: "\""
+          interpolated: true
+          remove_break: false
+    body:
+      - kind: function call
+        function:
+          kind: name
+          begin:
+            offset: 4185
+            line: 272
+          end:
+            offset: 4191
+            line: 272
+          value: notice
+        arguments:
+          - kind: variable
+            begin:
+              offset: 4192
+              line: 272
+            end:
+              offset: 4199
+              line: 272
+            name: param2
+  - kind: resource
+    begin:
+      offset: 4203
+      line: 275
+    end:
+      offset: 4242
+      line: 277
+    status: realized
+    type:
+      kind: name
+      begin:
+        offset: 4203
+        line: 275
+      end:
+        offset: 4215
+        line: 275
+      value: dt_ref_param
+    bodies:
+      - title:
+          kind: name
+          begin:
+            offset: 4218
+            line: 275
+          end:
+            offset: 4221
+            line: 275
+          value: foo
+        operations:
+          - name:
+              kind: name
+              begin:
+                offset: 4227
+                line: 276
+              end:
+                offset: 4233
+                line: 276
+              value: param1
+            operator_position:
+              offset: 4234
+              line: 276
+            operator: =>
+            value:
+              kind: name
+              begin:
+                offset: 4237
+                line: 276
+              end:
+                offset: 4240
+                line: 276
+              value: foo

--- a/lib/tests/fixtures/compiler/parser/good/sample.pp
+++ b/lib/tests/fixtures/compiler/parser/good/sample.pp
@@ -256,3 +256,22 @@ with(1, '2', [3], { 4 => 5}) |$a, $b, $c, $d| {
         fail incorrect
     }
 }
+
+class class_ref_param($param1, $param2 = "${param1}bar") {
+}
+
+class { class_ref_param:
+    param1 => foo
+}
+
+unless $class_ref_param::param2 == 'foobar' {
+    fail incorrect
+}
+
+define dt_ref_param($param1, $param2 = "${param1}bar") {
+    notice $param2
+}
+
+dt_ref_param { foo:
+    param1 => foo
+}


### PR DESCRIPTION
This fixes the call evaluator to properly evaluate a class or defined type's
parameters in declaration order, allowing later parameters to reference earlier
ones.

Example:

```
class foo($param1 = foo, $param2 = "${param1}bar") {
    notice $param2
}

include foo
```

This should output "foobar" and not "bar" because the evaluation order of the
parameters should be left-to-right, meaning $param1 gets set in scope before
$param2's default value is evaluated.

This also fixes the evaluator not properly handling duplicate parameter names
in classes and defined types.