### PR TITLE
(NPUP-24) Fix environment manifest search to be recursive.

### DIFF
--- a/lib/include/puppet/compiler/environment.hpp
+++ b/lib/include/puppet/compiler/environment.hpp
@@ -36,10 +36,9 @@ namespace puppet { namespace compiler {
          * Creates a new environment given the compiler settings.
          * @param logger The logger to use for logging messages.
          * @param settings The settings to use for the environment.
-         * @param manifests The main manifests to use instead of the environment's default.
          * @return Returns the new environment.
          */
-        static std::shared_ptr<environment> create(logging::logger& logger, compiler::settings settings, std::vector<std::string> const& manifests = {});
+        static std::shared_ptr<environment> create(logging::logger& logger, compiler::settings settings);
 
         /**
          * Gets the name of the environment.
@@ -79,17 +78,11 @@ namespace puppet { namespace compiler {
         std::deque<module> const& modules() const;
 
         /**
-         * Gets the environment's main manifests.
-         * Note: the manifest list will be empty unless load is called.
-         * @return Returns the environment's main manifests.
-         */
-        std::vector<std::string> const& manifests() const;
-
-        /**
          * Compiles the environment's manifests for the given evaluation context.
          * @param context The current evaluation context.
+         * @param manifests The main manifests to use instead of the environment's manifests.
          */
-        void compile(evaluation::context& context);
+        void compile(evaluation::context& context, std::vector<std::string> const& manifests = {});
 
         /**
          * Finds a module by name.
@@ -121,19 +114,14 @@ namespace puppet { namespace compiler {
 
      private:
         environment(std::string name, std::string directory, compiler::settings settings);
-        void populate(logging::logger& logger, std::vector<std::string> const& manifests);
-        void load_environment_settings(logging::logger& logger);
         void add_modules(logging::logger& logger);
         void add_modules(logging::logger& logger, std::string const& directory);
-        void add_manifests(logging::logger& logger);
-        void add_manifests(logging::logger& logger, std::string const& directory, bool throw_if_missing = false);
         std::shared_ptr<ast::syntax_tree> import(logging::logger& logger, std::string const& path, compiler::module const* module = nullptr);
 
         std::string _name;
         compiler::settings _settings;
         compiler::registry _registry;
         evaluation::dispatcher _dispatcher;
-        std::vector<std::string> _manifests;
         std::deque<module> _modules;
         std::unordered_map<std::string, module*> _module_map;
         std::unordered_map<std::string, std::shared_ptr<ast::syntax_tree>> _parsed;

--- a/lib/include/puppet/compiler/finder.hpp
+++ b/lib/include/puppet/compiler/finder.hpp
@@ -4,6 +4,7 @@
  */
 #pragma once
 
+#include "settings.hpp"
 #include <string>
 #include <memory>
 #include <functional>
@@ -29,8 +30,9 @@ namespace puppet { namespace compiler {
         /**
          * Constructs a new finder.
          * @param directory The directory for the finder to use.
+         * @param settings The settings to initialize with or nullptr to use default locations.
          */
-        explicit finder(std::string directory);
+        explicit finder(std::string directory, compiler::settings const* settings = nullptr);
 
         /**
          * Gets the directory used by the finder.
@@ -55,7 +57,10 @@ namespace puppet { namespace compiler {
         void each_file(find_type type, std::function<bool(std::string const&)> const& callback) const;
 
      private:
+        std::string const& base_path(find_type type) const;
+
         std::string _directory;
+        std::string _manifests_path;
     };
 
 }}  // puppet::compiler

--- a/lib/include/puppet/compiler/node.hpp
+++ b/lib/include/puppet/compiler/node.hpp
@@ -65,9 +65,10 @@ namespace puppet { namespace compiler {
 
         /**
          * Compiles manifests into a catalog for this node.
+         * @param manifests The main manifests to use instead of the environment's manifests.
          * @return Returns the compiled catalog for the node.
          */
-        catalog compile();
+        catalog compile(std::vector<std::string> const& manifests = {});
 
         /**
          * Calls the given callback for each name associated with the node.

--- a/lib/include/puppet/options/commands/compile.hpp
+++ b/lib/include/puppet/options/commands/compile.hpp
@@ -50,18 +50,6 @@ namespace puppet { namespace options { namespace commands {
 
      protected:
         /**
-         * Creates the command's hidden options.
-         * @return Returns the command's hidden options.
-         */
-        boost::program_options::options_description create_hidden_options() const override;
-
-        /**
-         * Creates the command's positional options.
-         * @return Returns the command's positional options.
-         */
-        boost::program_options::positional_options_description create_positional_options() const override;
-
-        /**
          * Creates an executor for the given parsed options.
          * @param options The parsed options.
          * @return Returns the command executor.

--- a/lib/src/compiler/finder.cc
+++ b/lib/src/compiler/finder.cc
@@ -1,28 +1,15 @@
 #include <puppet/compiler/finder.hpp>
+#include <puppet/utility/filesystem/helpers.hpp>
 #include <puppet/cast.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/filesystem.hpp>
 
 using namespace std;
+using namespace puppet::utility::filesystem;
 namespace fs = boost::filesystem;
 namespace sys = boost::system;
 
 namespace puppet { namespace compiler {
-
-    static fs::path base_path(find_type type, compiler::finder const& finder)
-    {
-        fs::path path = finder.directory();
-
-        switch (type) {
-            case find_type::manifest:
-                path /= "manifests";
-                break;
-
-            default:
-                throw runtime_error("unexpected file type.");
-        }
-        return path;
-    }
 
     static char const* extension(find_type type)
     {
@@ -35,45 +22,51 @@ namespace puppet { namespace compiler {
         }
     }
 
-    static bool each_file(fs::path const& directory, find_type type, function<bool(string const&)> const& callback)
+    static bool each_file(find_type type, fs::path const& directory, std::locale const& locale, function<bool(string const&)> const& callback)
     {
-        static std::locale locale{ "" };
-
-        // Build a list of paths contained in the given directory and sort based on the locale
         vector<fs::path> entries;
-        copy(fs::directory_iterator(directory), fs::directory_iterator(), back_inserter(entries));
+        copy_if(fs::directory_iterator{ directory }, fs::directory_iterator{}, back_inserter(entries),
+            [&](auto const& entry) {
+                // Add entries that are manifest files or directories that are not symlinks
+                return (fs::is_regular_file(entry.status()) && entry.path().extension() == extension(type)) ||
+                       (!fs::is_symlink(entry.symlink_status()) && fs::is_directory(entry.status()));
+            }
+        );
+
+        // Sort the entries into a deterministic order, based on the given locale
         sort(entries.begin(), entries.end(), [&](auto const& left, auto const& right) {
             return locale(left.string(), right.string());
         });
 
-        // Go through the entires; recurse into any directories and check for matching files
-        vector<fs::path const*> matches;
+        // Go through the entires; recurse into any directories
         for (auto& entry : entries) {
             sys::error_code ec;
             if (is_directory(entry, ec)) {
-                if (!each_file(entry, type, callback)) {
+                if (!each_file(type, entry, locale, callback)) {
                     return false;
                 }
                 continue;
             }
-            ec.clear();
-            if (is_regular_file(entry, ec) && entry.extension().string() == extension(type)) {
-                matches.emplace_back(&entry);
-                continue;
-            }
-        }
-        // Issue the callback for any matching files
-        for (auto& match : matches) {
-            if (!callback(match->string())) {
+            if (!callback(entry.string())) {
                 return false;
             }
         }
         return true;
     }
 
-    finder::finder(string directory) :
+    finder::finder(string directory, compiler::settings const* settings) :
         _directory(rvalue_cast(directory))
     {
+        if (settings) {
+            auto manifest = settings->get(settings::manifest);
+            if (manifest.as<string>()) {
+                _manifests_path = make_absolute(*manifest.as<string>(), _directory);
+            }
+        }
+        // Fall back to default search locations if not specified
+        if (_manifests_path.empty()) {
+            _manifests_path = make_absolute("manifests", _directory);
+        }
     }
 
     string const& finder::directory() const
@@ -87,9 +80,10 @@ namespace puppet { namespace compiler {
             return string();
         }
 
-        auto path = base_path(type, *this);
+        // Start with the base
+        fs::path path = base_path(type);
 
-       // Split the name on '::' and treat all but the last component as a subdirectory
+        // Split the name on '::' and treat all but the last component as a subdirectory
         boost::split_iterator<string::const_iterator> end;
         for (auto it = boost::make_split_iterator(name, boost::first_finder("::", boost::is_equal())); it != end; ++it) {
             path.append(it->begin(), it->end());
@@ -106,12 +100,32 @@ namespace puppet { namespace compiler {
 
     void finder::each_file(find_type type, function<bool(string const&)> const& callback) const
     {
-        auto directory = base_path(type, *this);
+        auto& base = base_path(type);
         sys::error_code ec;
-        if (!is_directory(directory, ec)) {
+        if (fs::is_regular_file(base, ec)) {
+            // If the base itself is to a file, treat it like a manifest
+            callback(base);
             return;
         }
-        compiler::each_file(directory, type, callback);
+        if (!fs::is_directory(base, ec)) {
+            return;
+        }
+
+        // The locale to sort the filenames with
+        // This defaults to the C locale to ensure a consistent sort regardless of the current user's locale
+        std::locale locale{};
+        compiler::each_file(type, base, locale, callback);
+    }
+
+    string const& finder::base_path(find_type type) const
+    {
+        switch (type) {
+            case find_type::manifest:
+                return _manifests_path;
+
+            default:
+                throw runtime_error("unexpected file type.");
+        }
     }
 
 }}  // namespace puppet::compiler

--- a/lib/src/compiler/node.cc
+++ b/lib/src/compiler/node.cc
@@ -52,7 +52,7 @@ namespace puppet { namespace compiler {
         return _facts;
     }
 
-    catalog node::compile()
+    catalog node::compile(vector<string> const& manifests)
     {
         try {
             compiler::catalog catalog{ name(), _environment->name() };
@@ -64,7 +64,7 @@ namespace puppet { namespace compiler {
             // TODO: set node parameters in the top scope
 
             // Compile the associated environment
-            _environment->compile(context);
+            _environment->compile(context, manifests);
 
             // TODO: evaluate node classes
 

--- a/lib/tests/compiler/environment.cc
+++ b/lib/tests/compiler/environment.cc
@@ -30,7 +30,11 @@ SCENARIO("environment with only manifests", "[environment]")
     auto& modules = environment->modules();
     REQUIRE(modules.empty());
 
-    auto& manifests = environment->manifests();
+    vector<string> manifests;
+    environment->each_file(find_type::manifest, [&](auto& path) {
+        manifests.emplace_back(path);
+        return true;
+    });
     REQUIRE(manifests.size() == 2);
     REQUIRE(manifests[0] == (manifests_dir / "bar.pp").string());
     REQUIRE(manifests[1] == (manifests_dir / "foo.pp").string());
@@ -65,7 +69,11 @@ SCENARIO("environment with modules", "[environment]")
     REQUIRE(modules[2].name() == "foo");
     REQUIRE(modules[2].directory() == (modules_dir / "foo").string());
 
-    auto& manifests = environment->manifests();
+    vector<string> manifests;
+    environment->each_file(find_type::manifest, [&](auto& path) {
+        manifests.emplace_back(path);
+        return true;
+    });
     REQUIRE(manifests.size() == 1);
     REQUIRE(manifests[0] == (manifests_dir / "site.pp").string());
 }
@@ -98,7 +106,11 @@ SCENARIO("environment with configuration file", "[environment]")
     REQUIRE(modules[2].name() == "zed");
     REQUIRE(modules[2].directory() == (modules_dir / "zed").string());
 
-    auto& manifests = environment->manifests();
+    vector<string> manifests;
+    environment->each_file(find_type::manifest, [&](auto& path) {
+        manifests.emplace_back(path);
+        return true;
+    });
     REQUIRE(manifests.size() == 1);
     REQUIRE(manifests[0] == (environment_dir / "site.pp").string());
 }


### PR DESCRIPTION
This fixes the `manifest` setting, when a directory (which is the default), to
recursively search for manifests in a deterministic order.

This commit removes the logic in the environment for searching for manifests
and consolidates the logic into the finder class.