### PR TITLE
(NPUP-26, NPUP-27) Fix bugs in class evaluation.

### DIFF
--- a/lib/src/compiler/registry.cc
+++ b/lib/src/compiler/registry.cc
@@ -51,7 +51,13 @@ namespace puppet { namespace compiler {
         if (!parent) {
             return context.node_or_top();
         }
-        return context.find_scope(context.declare_class(parent->value, *parent)->type().title());
+
+        auto scope = context.find_scope(context.declare_class(parent->value, *parent)->type().title());
+        if (!scope) {
+            // Because classes are added to the catalog before the scope is added to the context, a failure to find the scope means there is a circular inheritence
+            throw evaluation_exception((boost::format("cannot evaluate parent class '%1%' because it causes a circular inheritence.") % *parent).str(), *parent);
+        }
+        return scope;
     }
 
     defined_type::defined_type(string name, ast::defined_type_expression const& expression) :

--- a/lib/src/compiler/registry.cc
+++ b/lib/src/compiler/registry.cc
@@ -51,9 +51,7 @@ namespace puppet { namespace compiler {
         if (!parent) {
             return context.node_or_top();
         }
-
-        context.declare_class(parent->value, *parent);
-        return context.find_scope(parent->value);
+        return context.find_scope(context.declare_class(parent->value, *parent)->type().title());
     }
 
     defined_type::defined_type(string name, ast::defined_type_expression const& expression) :


### PR DESCRIPTION
Fixing two bugs in class evaluation:

1. Leading `::` in a parent class name would cause an unhandled exception.
2. Confusing error message when there is a circular class inheritance.