### PR TITLE
(NPUP-33) Implement the Iterator type.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,8 @@ include(cotire)
 
 enable_testing()
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=512 -Wall -Wextra -Werror -Wno-unused-parameter")
+# Disable PCH date-time check because Boost Spirit Lex uses __DATE__ and __TIME__ for static lexer generation
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -ftemplate-depth=512 -Wall -Wextra -Werror -Wno-unused-parameter -Wno-pch-date-time")
 
 if (${TEST_COVERAGE})
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -coverage")

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Expression evaluator status:
 * [x] local scope
 * [x] node scope
 * [x] string interpolation
+* [ ] Puppet type aliases
 * [x] custom functions written in Puppet
 * [ ] custom functions written in Ruby
 * [ ] custom types written in Puppet
@@ -91,6 +92,8 @@ Type system implemented:
 * [x] Float
 * [x] Hash
 * [x] Integer
+* [x] Iterable
+* [ ] Iterator
 * [x] Class
 * [x] NotUndef
 * [x] Numeric
@@ -143,15 +146,18 @@ Puppet functions implemented:
 * [x] reduce
 * [ ] regsubst
 * [x] require
+* [ ] reverse_each
 * [ ] scanf
 * [ ] sha1
 * [ ] shellquote
 * [ ] slice
 * [x] split
 * [ ] sprintf
+* [ ] step
 * [x] tag
 * [x] tagged
 * [ ] template
+* [ ] type
 * [x] versioncmp
 * [x] warning
 * [x] with

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ Type system implemented:
 * [x] Hash
 * [x] Integer
 * [x] Iterable
-* [ ] Iterator
+* [x] Iterator
 * [x] Class
 * [x] NotUndef
 * [x] Numeric

--- a/cmake/cotire.cmake
+++ b/cmake/cotire.cmake
@@ -3,7 +3,7 @@
 # See the cotire manual for usage hints.
 #
 #=============================================================================
-# Copyright 2012-2015 Sascha Kratky
+# Copyright 2012-2016 Sascha Kratky
 #
 # Permission is hereby granted, free of charge, to any person
 # obtaining a copy of this software and associated documentation
@@ -42,7 +42,20 @@ if (NOT CMAKE_SCRIPT_MODE_FILE)
 	cmake_policy(POP)
 endif()
 
+set (COTIRE_CMAKE_MODULE_FILE "${CMAKE_CURRENT_LIST_FILE}")
+set (COTIRE_CMAKE_MODULE_VERSION "1.7.7")
+
 # activate select policies
+if (POLICY CMP0025)
+	# Compiler id for Apple Clang is now AppleClang
+	cmake_policy(SET CMP0025 NEW)
+endif()
+
+if (POLICY CMP0026)
+	# disallow use of the LOCATION target property
+	cmake_policy(SET CMP0026 NEW)
+endif()
+
 if (POLICY CMP0038)
 	# targets may not link directly to themselves
 	cmake_policy(SET CMP0038 NEW)
@@ -92,9 +105,6 @@ if (POLICY CMP0054)
 	# only interpret if() arguments as variables or keywords when unquoted
 	cmake_policy(SET CMP0054 NEW)
 endif()
-
-set (COTIRE_CMAKE_MODULE_FILE "${CMAKE_CURRENT_LIST_FILE}")
-set (COTIRE_CMAKE_MODULE_VERSION "1.7.2")
 
 include(CMakeParseArguments)
 include(ProcessorCount)
@@ -321,7 +331,7 @@ function (cotire_get_target_usage_requirements _target _targetRequirementsVar)
 			list (FIND _targetRequirements ${_library} _index)
 			if (_index LESS 0)
 				list (APPEND _targetRequirements ${_library})
-				# process transitive libraries
+				# BFS traversal of transitive libraries
 				get_target_property(_libraries ${_library} INTERFACE_LINK_LIBRARIES)
 				if (_libraries)
 					list (APPEND _librariesToProcess ${_libraries})
@@ -379,6 +389,24 @@ function (cotire_filter_compile_flags _language _flagFilter _matchedOptionsVar _
 	set (${_unmatchedOptionsVar} ${_unmatchedOptions} PARENT_SCOPE)
 endfunction()
 
+function (cotire_is_target_supported _target _isSupportedVar)
+	if (NOT TARGET "${_target}")
+		set (${_isSupportedVar} FALSE PARENT_SCOPE)
+		return()
+	endif()
+	get_target_property(_imported ${_target} IMPORTED)
+	if (_imported)
+		set (${_isSupportedVar} FALSE PARENT_SCOPE)
+		return()
+	endif()
+	get_target_property(_targetType ${_target} TYPE)
+	if (NOT _targetType MATCHES "EXECUTABLE|(STATIC|SHARED|MODULE|OBJECT)_LIBRARY")
+		set (${_isSupportedVar} FALSE PARENT_SCOPE)
+		return()
+	endif()
+	set (${_isSupportedVar} TRUE PARENT_SCOPE)
+endfunction()
+
 function (cotire_get_target_compile_flags _config _language _target _flagsVar)
 	string (TOUPPER "${_config}" _upperConfig)
 	# collect options from CMake language variables
@@ -421,6 +449,27 @@ function (cotire_get_target_compile_flags _config _language _target _flagsVar)
 			endif()
 		endforeach()
 	endif()
+	# handle language standard properties
+	if (_target)
+		get_target_property(_targetLanguageStandard ${_target} ${_language}_STANDARD)
+		get_target_property(_targetLanguageExtensions ${_target} ${_language}_EXTENSIONS)
+		get_target_property(_targetLanguageStandardRequired ${_target} ${_language}_STANDARD_REQUIRED)
+		if (_targetLanguageExtensions)
+			if (CMAKE_${_language}${_targetLanguageExtensions}_EXTENSION_COMPILE_OPTION)
+				list (APPEND _compileFlags "${CMAKE_${_language}${_targetLanguageExtensions}_EXTENSION_COMPILE_OPTION}")
+			endif()
+		elseif (_targetLanguageStandard)
+			if (_targetLanguageStandardRequired)
+				if (CMAKE_${_language}${_targetLanguageStandard}_STANDARD_COMPILE_OPTION)
+					list (APPEND _compileFlags "${CMAKE_${_language}${_targetLanguageStandard}_STANDARD_COMPILE_OPTION}")
+				endif()
+			else()
+				if (CMAKE_${_language}${_targetLanguageStandard}_EXTENSION_COMPILE_OPTION)
+					list (APPEND _compileFlags "${CMAKE_${_language}${_targetLanguageStandard}_EXTENSION_COMPILE_OPTION}")
+				endif()
+			endif()
+		endif()
+	endif()
 	# handle the POSITION_INDEPENDENT_CODE target property
 	if (_target)
 		get_target_property(_targetPIC ${_target} POSITION_INDEPENDENT_CODE)
@@ -431,6 +480,17 @@ function (cotire_get_target_compile_flags _config _language _target _flagsVar)
 			elseif (CMAKE_${_language}_COMPILE_OPTIONS_PIC)
 				list (APPEND _compileFlags "${CMAKE_${_language}_COMPILE_OPTIONS_PIC}")
 			endif()
+		endif()
+	endif()
+	# handle visibility target properties
+	if (_target)
+		get_target_property(_targetVisibility ${_target} ${_language}_VISIBILITY_PRESET)
+		if (_targetVisibility AND CMAKE_${_language}_COMPILE_OPTIONS_VISIBILITY)
+			list (APPEND _compileFlags "${CMAKE_${_language}_COMPILE_OPTIONS_VISIBILITY}${_targetVisibility}")
+		endif()
+		get_target_property(_targetVisibilityInlines ${_target} VISIBILITY_INLINES_HIDDEN)
+		if (_targetVisibilityInlines AND CMAKE_${_language}_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN)
+			list (APPEND _compileFlags "${CMAKE_${_language}_COMPILE_OPTIONS_VISIBILITY_INLINES_HIDDEN}")
 		endif()
 	endif()
 	# platform specific flags
@@ -473,12 +533,31 @@ function (cotire_get_target_include_directories _config _language _target _inclu
 		list (APPEND _includeDirs "${CMAKE_CURRENT_BINARY_DIR}")
 		list (APPEND _includeDirs "${CMAKE_CURRENT_SOURCE_DIR}")
 	endif()
-	# parse additional include directories from target compile flags
 	set (_targetFlags "")
 	cotire_get_target_compile_flags("${_config}" "${_language}" "${_target}" _targetFlags)
-	cotire_filter_compile_flags("${_language}" "I" _dirs _ignore ${_targetFlags})
-	if (_dirs)
-		list (APPEND _includeDirs ${_dirs})
+	# parse additional include directories from target compile flags
+	if (CMAKE_INCLUDE_FLAG_${_language})
+		string (STRIP "${CMAKE_INCLUDE_FLAG_${_language}}" _includeFlag)
+		string (REGEX REPLACE "^[-/]+" "" _includeFlag "${_includeFlag}")
+		if (_includeFlag)
+			set (_dirs "")
+			cotire_filter_compile_flags("${_language}" "${_includeFlag}" _dirs _ignore ${_targetFlags})
+			if (_dirs)
+				list (APPEND _includeDirs ${_dirs})
+			endif()
+		endif()
+	endif()
+	# parse additional system include directories from target compile flags
+	if (CMAKE_INCLUDE_SYSTEM_FLAG_${_language})
+		string (STRIP "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}" _includeFlag)
+		string (REGEX REPLACE "^[-/]+" "" _includeFlag "${_includeFlag}")
+		if (_includeFlag)
+			set (_dirs "")
+			cotire_filter_compile_flags("${_language}" "${_includeFlag}" _dirs _ignore ${_targetFlags})
+			if (_dirs)
+				list (APPEND _systemIncludeDirs ${_dirs})
+			endif()
+		endif()
 	endif()
 	# target include directories
 	get_directory_property(_dirs DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}" INCLUDE_DIRECTORIES)
@@ -617,8 +696,23 @@ function (cotire_get_target_compiler_flags _config _language _target _compilerFl
 	# parse target compile flags omitting compile definitions and include directives
 	set (_targetFlags "")
 	cotire_get_target_compile_flags("${_config}" "${_language}" "${_target}" _targetFlags)
+	set (_flagFilter "D")
+	if (CMAKE_INCLUDE_FLAG_${_language})
+		string (STRIP "${CMAKE_INCLUDE_FLAG_${_language}}" _includeFlag)
+		string (REGEX REPLACE "^[-/]+" "" _includeFlag "${_includeFlag}")
+		if (_includeFlag)
+			set (_flagFilter "${_flagFilter}|${_includeFlag}")
+		endif()
+	endif()
+	if (CMAKE_INCLUDE_SYSTEM_FLAG_${_language})
+		string (STRIP "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}" _includeFlag)
+		string (REGEX REPLACE "^[-/]+" "" _includeFlag "${_includeFlag}")
+		if (_includeFlag)
+			set (_flagFilter "${_flagFilter}|${_includeFlag}")
+		endif()
+	endif()
 	set (_compilerFlags "")
-	cotire_filter_compile_flags("${_language}" "[ID]" _ignore _compilerFlags ${_targetFlags})
+	cotire_filter_compile_flags("${_language}" "${_flagFilter}" _ignore _compilerFlags ${_targetFlags})
 	if (COTIRE_DEBUG AND _compilerFlags)
 		message (STATUS "Target ${_target} compiler flags: ${_compilerFlags}")
 	endif()
@@ -739,7 +833,10 @@ macro (cotire_set_cmd_to_prologue _cmdVar)
 	endif()
 endmacro()
 
-function (cotire_init_compile_cmd _cmdVar _language _compilerExe _compilerArg1)
+function (cotire_init_compile_cmd _cmdVar _language _compilerLauncher _compilerExe _compilerArg1)
+	if (NOT _compilerLauncher)
+		set (_compilerLauncher ${CMAKE_${_language}_COMPILER_LAUNCHER})
+	endif()
 	if (NOT _compilerExe)
 		set (_compilerExe "${CMAKE_${_language}_COMPILER}")
 	endif()
@@ -747,7 +844,12 @@ function (cotire_init_compile_cmd _cmdVar _language _compilerExe _compilerArg1)
 		set (_compilerArg1 ${CMAKE_${_language}_COMPILER_ARG1})
 	endif()
 	string (STRIP "${_compilerArg1}" _compilerArg1)
-	set (${_cmdVar} "${_compilerExe}" ${_compilerArg1} PARENT_SCOPE)
+	if ("${CMAKE_GENERATOR}" MATCHES "Make|Ninja")
+		# compiler launcher is only supported for Makefile and Ninja
+		set (${_cmdVar} ${_compilerLauncher} "${_compilerExe}" ${_compilerArg1} PARENT_SCOPE)
+	else()
+		set (${_cmdVar} "${_compilerExe}" ${_compilerArg1} PARENT_SCOPE)
+	endif()
 endfunction()
 
 macro (cotire_add_definitions_to_cmd _cmdVar _language)
@@ -760,39 +862,66 @@ macro (cotire_add_definitions_to_cmd _cmdVar _language)
 	endforeach()
 endmacro()
 
-macro (cotire_add_includes_to_cmd _cmdVar _language _includeSystemFlag _includesVar _systemIncludesVar)
-	foreach (_include ${${_includesVar}})
-		if (WIN32 AND CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
-			file (TO_NATIVE_PATH "${_include}" _include)
-			list (APPEND ${_cmdVar} "/I${_include}")
-		else()
-			list (FIND ${_systemIncludesVar} ${_include} _index)
-			if(_index GREATER -1 AND NOT "${_includeSystemFlag}" STREQUAL "")
-				list (APPEND ${_cmdVar} "${_includeSystemFlag}${_include}")
+function (cotire_add_includes_to_cmd _cmdVar _language _includesVar _systemIncludesVar)
+	set (_includeDirs ${${_includesVar}} ${${_systemIncludesVar}})
+	if (_includeDirs)
+		list (REMOVE_DUPLICATES _includeDirs)
+		foreach (_include ${_includeDirs})
+			if (WIN32 AND CMAKE_${_language}_COMPILER_ID MATCHES "MSVC|Intel")
+				file (TO_NATIVE_PATH "${_include}" _include)
+				list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_${_language}_SEP}${_include}")
 			else()
-				list (APPEND ${_cmdVar} "-I${_include}")
-			endif()
-		endif()
-	endforeach()
-endmacro()
-
-macro (cotire_add_frameworks_to_cmd _cmdVar _language)
-	if (APPLE)
-		set (_frameWorkDirs "")
-		foreach (_include ${ARGN})
-			if (IS_ABSOLUTE "${_include}" AND _include MATCHES "\\.framework$")
-				get_filename_component(_frameWorkDir "${_include}" PATH)
-				list (APPEND _frameWorkDirs "${_frameWorkDir}")
+				set (_index -1)
+				if ("${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}" MATCHES ".+")
+					list (FIND ${_systemIncludesVar} "${_include}" _index)
+				endif()
+				if (_index GREATER -1)
+					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}${_include}")
+				else()
+					list (APPEND ${_cmdVar} "${CMAKE_INCLUDE_FLAG_${_language}}${CMAKE_INCLUDE_FLAG_${_language}_SEP}${_include}")
+				endif()
 			endif()
 		endforeach()
-		if (_frameWorkDirs)
-			list (REMOVE_DUPLICATES _frameWorkDirs)
-			foreach (_frameWorkDir ${_frameWorkDirs})
-				list (APPEND ${_cmdVar} "-F${_frameWorkDir}")
+	endif()
+	set (${_cmdVar} ${${_cmdVar}} PARENT_SCOPE)
+endfunction()
+
+function (cotire_add_frameworks_to_cmd _cmdVar _language _includesVar _systemIncludesVar)
+	if (APPLE)
+		set (_frameworkDirs "")
+		foreach (_include ${${_includesVar}})
+			if (IS_ABSOLUTE "${_include}" AND _include MATCHES "\\.framework$")
+				get_filename_component(_frameworkDir "${_include}" DIRECTORY)
+				list (APPEND _frameworkDirs "${_frameworkDir}")
+			endif()
+		endforeach()
+		set (_systemFrameworkDirs "")
+		foreach (_include ${${_systemIncludesVar}})
+			if (IS_ABSOLUTE "${_include}" AND _include MATCHES "\\.framework$")
+				get_filename_component(_frameworkDir "${_include}" DIRECTORY)
+				list (APPEND _systemFrameworkDirs "${_frameworkDir}")
+			endif()
+		endforeach()
+		if (_systemFrameworkDirs)
+			list (APPEND _frameworkDirs ${_systemFrameworkDirs})
+		endif()
+		if (_frameworkDirs)
+			list (REMOVE_DUPLICATES _frameworkDirs)
+			foreach (_frameworkDir ${_frameworkDirs})
+				set (_index -1)
+				if ("${CMAKE_${_language}_SYSTEM_FRAMEWORK_SEARCH_FLAG}" MATCHES ".+")
+					list (FIND _systemFrameworkDirs "${_frameworkDir}" _index)
+				endif()
+				if (_index GREATER -1)
+					list (APPEND ${_cmdVar} "${CMAKE_${_language}_SYSTEM_FRAMEWORK_SEARCH_FLAG}${_frameworkDir}")
+				else()
+					list (APPEND ${_cmdVar} "${CMAKE_${_language}_FRAMEWORK_SEARCH_FLAG}${_frameworkDir}")
+				endif()
 			endforeach()
 		endif()
 	endif()
-endmacro()
+	set (${_cmdVar} ${${_cmdVar}} PARENT_SCOPE)
+endfunction()
 
 macro (cotire_add_compile_flags_to_cmd _cmdVar)
 	foreach (_flag ${ARGN})
@@ -1040,9 +1169,9 @@ endfunction()
 
 function (cotire_scan_includes _includesVar)
 	set(_options "")
-	set(_oneValueArgs COMPILER_ID COMPILER_EXECUTABLE COMPILER_VERSION INCLUDE_SYSTEM_FLAG LANGUAGE UNPARSED_LINES)
+	set(_oneValueArgs COMPILER_ID COMPILER_EXECUTABLE COMPILER_ARG1 COMPILER_VERSION LANGUAGE UNPARSED_LINES)
 	set(_multiValueArgs COMPILE_DEFINITIONS COMPILE_FLAGS INCLUDE_DIRECTORIES SYSTEM_INCLUDE_DIRECTORIES
-		IGNORE_PATH INCLUDE_PATH IGNORE_EXTENSIONS INCLUDE_PRIORITY_PATH)
+		IGNORE_PATH INCLUDE_PATH IGNORE_EXTENSIONS INCLUDE_PRIORITY_PATH COMPILER_LAUNCHER)
 	cmake_parse_arguments(_option "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 	set (_sourceFiles ${_option_UNPARSED_ARGUMENTS})
 	if (NOT _option_LANGUAGE)
@@ -1054,12 +1183,11 @@ function (cotire_scan_includes _includesVar)
 	if (NOT _option_COMPILER_VERSION)
 		set (_option_COMPILER_VERSION "${CMAKE_${_option_LANGUAGE}_COMPILER_VERSION}")
 	endif()
-	set (_cmd "${_option_COMPILER_EXECUTABLE}" ${_option_COMPILER_ARG1})
-	cotire_init_compile_cmd(_cmd "${_option_LANGUAGE}" "${_option_COMPILER_EXECUTABLE}" "${_option_COMPILER_ARG1}")
+	cotire_init_compile_cmd(_cmd "${_option_LANGUAGE}" "${_option_COMPILER_LAUNCHER}" "${_option_COMPILER_EXECUTABLE}" "${_option_COMPILER_ARG1}")
 	cotire_add_definitions_to_cmd(_cmd "${_option_LANGUAGE}" ${_option_COMPILE_DEFINITIONS})
 	cotire_add_compile_flags_to_cmd(_cmd ${_option_COMPILE_FLAGS})
-	cotire_add_includes_to_cmd(_cmd "${_option_LANGUAGE}" "${_option_INCLUDE_SYSTEM_FLAG}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
-	cotire_add_frameworks_to_cmd(_cmd "${_option_LANGUAGE}" ${_option_INCLUDE_DIRECTORIES})
+	cotire_add_includes_to_cmd(_cmd "${_option_LANGUAGE}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
+	cotire_add_frameworks_to_cmd(_cmd "${_option_LANGUAGE}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
 	cotire_add_makedep_flags("${_option_LANGUAGE}" "${_option_COMPILER_ID}" "${_option_COMPILER_VERSION}" _cmd)
 	# only consider existing source files for scanning
 	set (_existingSourceFiles "")
@@ -1252,10 +1380,10 @@ endfunction()
 
 function (cotire_generate_prefix_header _prefixFile)
 	set(_options "")
-	set(_oneValueArgs LANGUAGE COMPILER_EXECUTABLE COMPILER_ID COMPILER_VERSION INCLUDE_SYSTEM_FLAG)
+	set(_oneValueArgs LANGUAGE COMPILER_EXECUTABLE COMPILER_ARG1 COMPILER_ID COMPILER_VERSION)
 	set(_multiValueArgs DEPENDS COMPILE_DEFINITIONS COMPILE_FLAGS
 		INCLUDE_DIRECTORIES SYSTEM_INCLUDE_DIRECTORIES IGNORE_PATH INCLUDE_PATH
-		IGNORE_EXTENSIONS INCLUDE_PRIORITY_PATH)
+		IGNORE_EXTENSIONS INCLUDE_PRIORITY_PATH COMPILER_LAUNCHER)
 	cmake_parse_arguments(_option "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 	if (NOT _option_COMPILER_ID)
 		set (_option_COMPILER_ID "${CMAKE_${_option_LANGUAGE}_ID}")
@@ -1288,13 +1416,14 @@ function (cotire_generate_prefix_header _prefixFile)
 	set (_sourceFiles ${_option_UNPARSED_ARGUMENTS})
 	cotire_scan_includes(_selectedHeaders ${_sourceFiles}
 		LANGUAGE "${_option_LANGUAGE}"
+		COMPILER_LAUNCHER "${_option_COMPILER_LAUNCHER}"
 		COMPILER_EXECUTABLE "${_option_COMPILER_EXECUTABLE}"
+		COMPILER_ARG1 "${_option_COMPILER_ARG1}"
 		COMPILER_ID "${_option_COMPILER_ID}"
 		COMPILER_VERSION "${_option_COMPILER_VERSION}"
 		COMPILE_DEFINITIONS ${_option_COMPILE_DEFINITIONS}
 		COMPILE_FLAGS ${_option_COMPILE_FLAGS}
 		INCLUDE_DIRECTORIES ${_option_INCLUDE_DIRECTORIES}
-		INCLUDE_SYSTEM_FLAG ${_option_INCLUDE_SYSTEM_FLAG}
 		SYSTEM_INCLUDE_DIRECTORIES ${_option_SYSTEM_INCLUDE_DIRECTORIES}
 		IGNORE_PATH ${_option_IGNORE_PATH}
 		INCLUDE_PATH ${_option_INCLUDE_PATH}
@@ -1487,7 +1616,7 @@ function (cotire_add_pch_compilation_flags _language _compilerID _compilerVersio
 			# -Kc++ process all source or unrecognized file types as C++ source files
 			# -fsyntax-only check only for correct syntax
 			# -Wpch-messages enable diagnostics related to pre-compiled headers (requires Intel XE 2013 Update 2)
-			get_filename_component(_pchDir "${_pchFile}" PATH)
+			get_filename_component(_pchDir "${_pchFile}" DIRECTORY)
 			get_filename_component(_pchName "${_pchFile}" NAME)
 			set (_xLanguage_C "c-header")
 			set (_xLanguage_CXX "c++-header")
@@ -1613,7 +1742,7 @@ function (cotire_add_prefix_pch_inclusion_flags _language _compilerID _compilerV
 			# -include process include file as the first line of the primary source file
 			# -Wpch-messages enable diagnostics related to pre-compiled headers (requires Intel XE 2013 Update 2)
 			if (_pchFile)
-				get_filename_component(_pchDir "${_pchFile}" PATH)
+				get_filename_component(_pchDir "${_pchFile}" DIRECTORY)
 				get_filename_component(_pchName "${_pchFile}" NAME)
 				if (_flags)
 					# append to list
@@ -1647,8 +1776,8 @@ endfunction()
 
 function (cotire_precompile_prefix_header _prefixFile _pchFile _hostFile)
 	set(_options "")
-	set(_oneValueArgs COMPILER_EXECUTABLE COMPILER_ID COMPILER_VERSION INCLUDE_SYSTEM_FLAG LANGUAGE)
-	set(_multiValueArgs COMPILE_DEFINITIONS COMPILE_FLAGS INCLUDE_DIRECTORIES SYSTEM_INCLUDE_DIRECTORIES SYS)
+	set(_oneValueArgs COMPILER_EXECUTABLE COMPILER_ARG1 COMPILER_ID COMPILER_VERSION LANGUAGE)
+	set(_multiValueArgs COMPILE_DEFINITIONS COMPILE_FLAGS INCLUDE_DIRECTORIES SYSTEM_INCLUDE_DIRECTORIES SYS COMPILER_LAUNCHER)
 	cmake_parse_arguments(_option "${_options}" "${_oneValueArgs}" "${_multiValueArgs}" ${ARGN})
 	if (NOT _option_LANGUAGE)
 		set (_option_LANGUAGE "CXX")
@@ -1659,11 +1788,11 @@ function (cotire_precompile_prefix_header _prefixFile _pchFile _hostFile)
 	if (NOT _option_COMPILER_VERSION)
 		set (_option_COMPILER_VERSION "${CMAKE_${_option_LANGUAGE}_COMPILER_VERSION}")
 	endif()
-	cotire_init_compile_cmd(_cmd "${_option_LANGUAGE}" "${_option_COMPILER_EXECUTABLE}" "${_option_COMPILER_ARG1}")
+	cotire_init_compile_cmd(_cmd "${_option_LANGUAGE}" "${_option_COMPILER_LAUNCHER}" "${_option_COMPILER_EXECUTABLE}" "${_option_COMPILER_ARG1}")
 	cotire_add_definitions_to_cmd(_cmd "${_option_LANGUAGE}" ${_option_COMPILE_DEFINITIONS})
 	cotire_add_compile_flags_to_cmd(_cmd ${_option_COMPILE_FLAGS})
-	cotire_add_includes_to_cmd(_cmd "${_option_LANGUAGE}" "${_option_INCLUDE_SYSTEM_FLAG}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
-	cotire_add_frameworks_to_cmd(_cmd "${_option_LANGUAGE}" ${_option_INCLUDE_DIRECTORIES})
+	cotire_add_includes_to_cmd(_cmd "${_option_LANGUAGE}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
+	cotire_add_frameworks_to_cmd(_cmd "${_option_LANGUAGE}" _option_INCLUDE_DIRECTORIES _option_SYSTEM_INCLUDE_DIRECTORIES)
 	cotire_add_pch_compilation_flags(
 		"${_option_LANGUAGE}" "${_option_COMPILER_ID}" "${_option_COMPILER_VERSION}"
 		"${_prefixFile}" "${_pchFile}" "${_hostFile}" _cmd)
@@ -1710,7 +1839,8 @@ function (cotire_check_precompiled_header_support _language _target _msgVar)
 	else()
 		set (${_msgVar} "${_unsupportedCompiler}." PARENT_SCOPE)
 	endif()
-	if (CMAKE_${_language}_COMPILER MATCHES "ccache")
+	get_target_property(_launcher ${_target} ${_language}_COMPILER_LAUNCHER)
+	if (CMAKE_${_language}_COMPILER MATCHES "ccache" OR _launcher MATCHES "ccache")
 		if (NOT "$ENV{CCACHE_SLOPPINESS}" MATCHES "time_macros|pch_defines")
 			set (${_msgVar}
 				"ccache requires the environment variable CCACHE_SLOPPINESS to be set to \"pch_defines,time_macros\"."
@@ -1940,14 +2070,6 @@ function (cotire_get_prefix_header_dependencies _language _target _dependencySou
 	# depend on target source files marked with custom COTIRE_DEPENDENCY property
 	get_target_property(_targetSourceFiles ${_target} SOURCES)
 	cotire_get_objects_with_property_on(_dependencySources COTIRE_DEPENDENCY SOURCE ${_targetSourceFiles})
-	if (CMAKE_${_language}_COMPILER_ID MATCHES "GNU|Clang")
-		# GCC and clang raise a fatal error if a file is not found during preprocessing
-		# thus we depend on target's generated source files for prefix header generation
-		cotire_get_objects_with_property_on(_generatedSources GENERATED SOURCE ${_targetSourceFiles})
-		if (_generatedSources)
-			list (APPEND _dependencySources ${_generatedSources})
-		endif()
-	endif()
 	if (COTIRE_DEBUG AND _dependencySources)
 		message (STATUS "${_language} ${_target} prefix header dependencies: ${_dependencySources}")
 	endif()
@@ -1970,7 +2092,6 @@ function (cotire_generate_target_script _language _configurations _target _targe
 	get_target_property(COTIRE_TARGET_INCLUDE_PRIORITY_PATH ${_target} COTIRE_PREFIX_HEADER_INCLUDE_PRIORITY_PATH)
 	cotire_get_source_files_undefs(COTIRE_UNITY_SOURCE_PRE_UNDEFS COTIRE_TARGET_SOURCES_PRE_UNDEFS ${_targetSources})
 	cotire_get_source_files_undefs(COTIRE_UNITY_SOURCE_POST_UNDEFS COTIRE_TARGET_SOURCES_POST_UNDEFS ${_targetSources})
-	string (STRIP "${CMAKE_INCLUDE_SYSTEM_FLAG_${_language}}" COTIRE_INCLUDE_SYSTEM_FLAG)
 	set (COTIRE_TARGET_CONFIGURATION_TYPES "${_configurations}")
 	foreach (_config ${_configurations})
 		string (TOUPPER "${_config}" _upperConfig)
@@ -1983,6 +2104,7 @@ function (cotire_generate_target_script _language _configurations _target _targe
 		cotire_get_source_files_compile_definitions(
 			"${_config}" "${_language}" COTIRE_TARGET_SOURCES_COMPILE_DEFINITIONS_${_upperConfig} ${_targetSources})
 	endforeach()
+	get_target_property(COTIRE_TARGET_${_language}_COMPILER_LAUNCHER ${_target} ${_language}_COMPILER_LAUNCHER)
 	# set up COTIRE_TARGET_SOURCES
 	set (COTIRE_TARGET_SOURCES "")
 	foreach (_sourceFile ${_targetSources})
@@ -1998,14 +2120,23 @@ function (cotire_generate_target_script _language _configurations _target _targe
 	# copy variable definitions to cotire target script
 	get_cmake_property(_vars VARIABLES)
 	string (REGEX MATCHALL "COTIRE_[A-Za-z0-9_]+" _matchVars "${_vars}")
-	# remove COTIRE_VERBOSE which is passed as a CMake define on command line
+	# omit COTIRE_*_INIT variables
+	string (REGEX MATCHALL "COTIRE_[A-Za-z0-9_]+_INIT" _initVars "${_matchVars}")
+	if (_initVars)
+		list (REMOVE_ITEM _matchVars ${_initVars})
+	endif()
+	# omit COTIRE_VERBOSE which is passed as a CMake define on command line
 	list (REMOVE_ITEM _matchVars COTIRE_VERBOSE)
 	set (_contents "")
 	set (_contentsHasGeneratorExpressions FALSE)
 	foreach (_var IN LISTS _matchVars ITEMS
 		XCODE MSVC CMAKE_GENERATOR CMAKE_BUILD_TYPE CMAKE_CONFIGURATION_TYPES
 		CMAKE_${_language}_COMPILER_ID CMAKE_${_language}_COMPILER_VERSION
-		CMAKE_${_language}_COMPILER CMAKE_${_language}_COMPILER_ARG1
+		CMAKE_${_language}_COMPILER_LAUNCHER CMAKE_${_language}_COMPILER CMAKE_${_language}_COMPILER_ARG1
+		CMAKE_INCLUDE_FLAG_${_language} CMAKE_INCLUDE_FLAG_${_language}_SEP
+		CMAKE_INCLUDE_SYSTEM_FLAG_${_language}
+		CMAKE_${_language}_FRAMEWORK_SEARCH_FLAG
+		CMAKE_${_language}_SYSTEM_FRAMEWORK_SEARCH_FLAG
 		CMAKE_${_language}_SOURCE_FILE_EXTENSIONS)
 		if (DEFINED ${_var})
 			string (REPLACE "\"" "\\\"" _value "${${_var}}")
@@ -2055,7 +2186,11 @@ function (cotire_setup_pch_file_compilation _language _target _targetScript _pre
 		if (_targetScript)
 			cotire_set_cmd_to_prologue(_cmds)
 			list (APPEND _cmds -P "${COTIRE_CMAKE_MODULE_FILE}" "precompile" "${_targetScript}" "${_prefixFile}" "${_pchFile}" "${_hostFile}")
-			file (RELATIVE_PATH _pchFileRelPath "${CMAKE_BINARY_DIR}" "${_pchFile}")
+			if (MSVC_IDE)
+				file (TO_NATIVE_PATH "${_pchFile}" _pchFileLogPath)
+			else()
+				file (RELATIVE_PATH _pchFileLogPath "${CMAKE_BINARY_DIR}" "${_pchFile}")
+			endif()
 			if (COTIRE_DEBUG)
 				message (STATUS "add_custom_command: OUTPUT ${_pchFile} ${_cmds} DEPENDS ${_prefixFile} IMPLICIT_DEPENDS ${_language} ${_prefixFile}")
 			endif()
@@ -2066,7 +2201,7 @@ function (cotire_setup_pch_file_compilation _language _target _targetScript _pre
 				DEPENDS "${_prefixFile}"
 				IMPLICIT_DEPENDS ${_language} "${_prefixFile}"
 				WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
-				COMMENT "Building ${_language} precompiled header ${_pchFileRelPath}"
+				COMMENT "Building ${_language} precompiled header ${_pchFileLogPath}"
 				VERBATIM)
 		endif()
 	endif()
@@ -2151,19 +2286,23 @@ function (cotire_setup_combine_command _language _targetScript _joinedFile _cmds
 		message (STATUS "add_custom_command: OUTPUT ${_joinedFile} COMMAND ${_prefixCmd} DEPENDS ${_files}")
 	endif()
 	set_property (SOURCE "${_joinedFile}" PROPERTY GENERATED TRUE)
-	file (RELATIVE_PATH _joinedFileRelPath "${CMAKE_BINARY_DIR}" "${_joinedFile}")
+	if (MSVC_IDE)
+		file (TO_NATIVE_PATH "${_joinedFile}" _joinedFileLogPath)
+	else()
+		file (RELATIVE_PATH _joinedFileLogPath "${CMAKE_BINARY_DIR}" "${_joinedFile}")
+	endif()
 	get_filename_component(_joinedFileBaseName "${_joinedFile}" NAME_WE)
 	get_filename_component(_joinedFileExt "${_joinedFile}" EXT)
 	if (_language AND _joinedFileBaseName MATCHES "${COTIRE_UNITY_SOURCE_FILENAME_SUFFIX}$")
-		set (_comment "Generating ${_language} unity source ${_joinedFileRelPath}")
+		set (_comment "Generating ${_language} unity source ${_joinedFileLogPath}")
 	elseif (_language AND _joinedFileBaseName MATCHES "${COTIRE_PREFIX_HEADER_FILENAME_SUFFIX}$")
 		if (_joinedFileExt MATCHES "^\\.c")
-			set (_comment "Generating ${_language} prefix source ${_joinedFileRelPath}")
+			set (_comment "Generating ${_language} prefix source ${_joinedFileLogPath}")
 		else()
-			set (_comment "Generating ${_language} prefix header ${_joinedFileRelPath}")
+			set (_comment "Generating ${_language} prefix header ${_joinedFileLogPath}")
 		endif()
 	else()
-		set (_comment "Generating ${_joinedFileRelPath}")
+		set (_comment "Generating ${_joinedFileLogPath}")
 	endif()
 	add_custom_command(
 		OUTPUT "${_joinedFile}"
@@ -2264,7 +2403,11 @@ function (cotire_setup_unity_generation_commands _language _target _targetScript
 			# CMake 3.1.0 supports generator expressions in arguments to DEPENDS
 			set (_unityCmdDepends "${_targetConfigScript}")
 		endif()
-		file (RELATIVE_PATH _unityFileRelPath "${CMAKE_BINARY_DIR}" "${_unityFile}")
+		if (MSVC_IDE)
+			file (TO_NATIVE_PATH "${_unityFile}" _unityFileLogPath)
+		else()
+			file (RELATIVE_PATH _unityFileLogPath "${CMAKE_BINARY_DIR}" "${_unityFile}")
+		endif()
 		if (COTIRE_DEBUG)
 			message (STATUS "add_custom_command: OUTPUT ${_unityFile} COMMAND ${_unityCmd} DEPENDS ${_unityCmdDepends}")
 		endif()
@@ -2272,41 +2415,55 @@ function (cotire_setup_unity_generation_commands _language _target _targetScript
 			OUTPUT "${_unityFile}"
 			COMMAND ${_unityCmd}
 			DEPENDS ${_unityCmdDepends}
-			COMMENT "Generating ${_language} unity source ${_unityFileRelPath}"
+			COMMENT "Generating ${_language} unity source ${_unityFileLogPath}"
 			WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 			VERBATIM)
 		list (APPEND ${_cmdsVar} COMMAND ${_unityCmd})
 	endforeach()
-	list (LENGTH _unityFiles _numberOfUnityFiles)
-	if (_numberOfUnityFiles GREATER 1)
-		# create a joint unity file from all unity file segments
-		cotire_make_single_unity_source_file_path(${_language} ${_target} _unityFile)
-		cotire_setup_combine_command(${_language} "${_targetConfigScript}" "${_unityFile}" ${_cmdsVar} ${_unityFiles})
-	endif()
 	set (${_cmdsVar} ${${_cmdsVar}} PARENT_SCOPE)
 endfunction()
 
-function (cotire_setup_prefix_generation_command _language _target _targetScript _prefixFile _unityFile _cmdsVar)
+function (cotire_setup_prefix_generation_command _language _target _targetScript _prefixFile _unityFiles _cmdsVar)
 	set (_sourceFiles ${ARGN})
 	set (_dependencySources "")
 	cotire_get_prefix_header_dependencies(${_language} ${_target} _dependencySources ${_sourceFiles})
 	cotire_set_cmd_to_prologue(_prefixCmd)
-	list (APPEND _prefixCmd -P "${COTIRE_CMAKE_MODULE_FILE}" "prefix" "${_targetScript}" "${_prefixFile}" "${_unityFile}")
+	list (APPEND _prefixCmd -P "${COTIRE_CMAKE_MODULE_FILE}" "prefix" "${_targetScript}" "${_prefixFile}" ${_unityFiles})
 	set_property (SOURCE "${_prefixFile}" PROPERTY GENERATED TRUE)
 	if (COTIRE_DEBUG)
 		message (STATUS "add_custom_command: OUTPUT ${_prefixFile} COMMAND ${_prefixCmd} DEPENDS ${_unityFile} ${_dependencySources}")
 	endif()
-	file (RELATIVE_PATH _prefixFileRelPath "${CMAKE_BINARY_DIR}" "${_prefixFile}")
+	if (MSVC_IDE)
+		file (TO_NATIVE_PATH "${_prefixFile}" _prefixFileLogPath)
+	else()
+		file (RELATIVE_PATH _prefixFileLogPath "${CMAKE_BINARY_DIR}" "${_prefixFile}")
+	endif()
 	get_filename_component(_prefixFileExt "${_prefixFile}" EXT)
 	if (_prefixFileExt MATCHES "^\\.c")
-		set (_comment "Generating ${_language} prefix source ${_prefixFileRelPath}")
+		set (_comment "Generating ${_language} prefix source ${_prefixFileLogPath}")
 	else()
-		set (_comment "Generating ${_language} prefix header ${_prefixFileRelPath}")
+		set (_comment "Generating ${_language} prefix header ${_prefixFileLogPath}")
+	endif()
+	# prevent pre-processing errors upon generating the prefix header when a target's generated include file does not yet exist
+	# we do not add a file-level dependency for the target's generated files though, because we only want to depend on their existence
+	# thus we make the prefix header generation depend on a custom helper target which triggers the generation of the files
+	set (_preTargetName "${_target}${COTIRE_PCH_TARGET_SUFFIX}_pre")
+	if (TARGET ${_preTargetName})
+		# custom helper target has already been generated while processing a different language
+		list (APPEND _dependencySources ${_preTargetName})
+	else()
+		get_target_property(_targetSourceFiles ${_target} SOURCES)
+		cotire_get_objects_with_property_on(_generatedSources GENERATED SOURCE ${_targetSourceFiles})
+		if (_generatedSources)
+			add_custom_target("${_preTargetName}" DEPENDS ${_generatedSources})
+			cotire_init_target("${_preTargetName}")
+			list (APPEND _dependencySources ${_preTargetName})
+		endif()
 	endif()
 	add_custom_command(
 		OUTPUT "${_prefixFile}" "${_prefixFile}.log"
 		COMMAND ${_prefixCmd}
-		DEPENDS "${_unityFile}" ${_dependencySources}
+		DEPENDS ${_unityFiles} ${_dependencySources}
 		COMMENT "${_comment}"
 		WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
 		VERBATIM)
@@ -2322,17 +2479,9 @@ function (cotire_setup_prefix_generation_from_unity_command _language _target _t
 	else()
 		set (_prefixSourceFile "${_prefixFile}")
 	endif()
-	list (LENGTH _unityFiles _numberOfUnityFiles)
-	if (_numberOfUnityFiles GREATER 1)
-		cotire_make_single_unity_source_file_path(${_language} ${_target} _unityFile)
-		cotire_setup_prefix_generation_command(
-			${_language} ${_target} "${_targetScript}"
-			"${_prefixSourceFile}" "${_unityFile}" ${_cmdsVar} ${_sourceFiles})
-	else()
-		cotire_setup_prefix_generation_command(
-			${_language} ${_target} "${_targetScript}"
-			"${_prefixSourceFile}" "${_unityFiles}" ${_cmdsVar} ${_sourceFiles})
-	endif()
+	cotire_setup_prefix_generation_command(
+		${_language} ${_target} "${_targetScript}"
+		"${_prefixSourceFile}" "${_unityFiles}" ${_cmdsVar} ${_sourceFiles})
 	if (CMAKE_${_language}_COMPILER_ID MATCHES "GNU|Clang")
 		# set up generation of a prefix source file which includes the prefix header
 		cotire_setup_combine_command(${_language} "${_targetScript}" "${_prefixFile}" _cmds ${_prefixSourceFile})
@@ -2475,7 +2624,7 @@ function (cotire_choose_target_languages _target _targetLanguagesVar _wholeTarge
 			set (${_targetLanguagesVar} "" PARENT_SCOPE)
 			return()
 		endif()
-		if (_targetUsePCH AND "${_language}" MATCHES "^C|CXX$")
+		if (_targetUsePCH AND "${_language}" MATCHES "^C|CXX$" AND NOT "${CMAKE_${_language}_COMPILER_ID}" STREQUAL "")
 			cotire_check_precompiled_header_support("${_language}" "${_target}" _disableMsg)
 			if (_disableMsg)
 				set (_targetUsePCH FALSE)
@@ -2566,10 +2715,6 @@ function (cotire_compute_unity_max_number_of_includes _target _maxIncludesVar)
 		endif()
 		list (LENGTH _sourceFiles _numberOfSources)
 		math (EXPR _maxIncludes "(${_numberOfSources} + ${_numberOfThreads} - 1) / ${_numberOfThreads}")
-		# a unity source segment must not contain less than COTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES files
-		if (_maxIncludes LESS ${COTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES})
-			set (_maxIncludes ${COTIRE_MINIMUM_NUMBER_OF_TARGET_SOURCES})
-		endif()
 	elseif (NOT _maxIncludes MATCHES "[0-9]+")
 		set (_maxIncludes 0)
 	endif()
@@ -2597,14 +2742,22 @@ function (cotire_process_target_language _language _configurations _target _whol
 	endif()
 	cotire_generate_target_script(
 		${_language} "${_configurations}" ${_target} _targetScript _targetConfigScript ${_unitySourceFiles})
+	# set up unity files for parallel compilation
 	cotire_compute_unity_max_number_of_includes(${_target} _maxIncludes ${_unitySourceFiles})
 	cotire_make_unity_source_file_paths(${_language} ${_target} ${_maxIncludes} _unityFiles ${_unitySourceFiles})
-	if (NOT _unityFiles)
+	list (LENGTH _unityFiles _numberOfUnityFiles)
+	if (_numberOfUnityFiles EQUAL 0)
 		return()
+	elseif (_numberOfUnityFiles GREATER 1)
+		cotire_setup_unity_generation_commands(
+			${_language} ${_target} "${_targetScript}" "${_targetConfigScript}" "${_unityFiles}" _cmds ${_unitySourceFiles})
 	endif()
+	# set up single unity file for prefix header generation
+	cotire_make_single_unity_source_file_path(${_language} ${_target} _unityFile)
 	cotire_setup_unity_generation_commands(
-		${_language} ${_target} "${_targetScript}" "${_targetConfigScript}" "${_unityFiles}" _cmds ${_unitySourceFiles})
+		${_language} ${_target} "${_targetScript}" "${_targetConfigScript}" "${_unityFile}" _cmds ${_unitySourceFiles})
 	cotire_make_prefix_file_path(${_language} ${_target} _prefixFile)
+	# set up prefix header
 	if (_prefixFile)
 		# check for user provided prefix header files
 		get_property(_prefixHeaderFiles TARGET ${_target} PROPERTY COTIRE_${_language}_PREFIX_HEADER_INIT)
@@ -2613,7 +2766,7 @@ function (cotire_process_target_language _language _configurations _target _whol
 				${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" _cmds ${_prefixHeaderFiles})
 		else()
 			cotire_setup_prefix_generation_from_unity_command(
-				${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" "${_unityFiles}" _cmds ${_unitySourceFiles})
+				${_language} ${_target} "${_targetConfigScript}" "${_prefixFile}" "${_unityFile}" _cmds ${_unitySourceFiles})
 		endif()
 		# check if selected language has enough sources at all
 		list (LENGTH _sourceFiles _numberOfSources)
@@ -2708,6 +2861,20 @@ function (cotire_collect_unity_target_sources _target _languages _unityTargetSou
 		endif()
 	endforeach()
 	set (${_unityTargetSourcesVar} ${_unityTargetSources} PARENT_SCOPE)
+endfunction()
+
+function (cotire_setup_unity_target_pch_usage _languages _target)
+	foreach (_language ${_languages})
+		get_property(_unityFiles TARGET ${_target} PROPERTY COTIRE_${_language}_UNITY_SOURCE)
+		if (_unityFiles)
+			get_property(_userPrefixFile TARGET ${_target} PROPERTY COTIRE_${_language}_PREFIX_HEADER_INIT)
+			get_property(_prefixFile TARGET ${_target} PROPERTY COTIRE_${_language}_PREFIX_HEADER)
+			if (_userPrefixFile AND _prefixFile)
+				# user provided prefix header must be included unconditionally by unity sources
+				cotire_setup_prefix_file_inclusion(${_language} ${_target} "${_prefixFile}" ${_unityFiles})
+			endif()
+		endif()
+	endforeach()
 endfunction()
 
 function (cotire_setup_unity_build_target _languages _configurations _target)
@@ -2806,6 +2973,8 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		INCLUDE_DIRECTORIES
 		INTERPROCEDURAL_OPTIMIZATION INTERPROCEDURAL_OPTIMIZATION_<CONFIG>
 		POSITION_INDEPENDENT_CODE
+		C_COMPILER_LAUNCHER CXX_COMPILER_LAUNCHER
+		C_INCLUDE_WHAT_YOU_USE CXX_INCLUDE_WHAT_YOU_USE
 		C_VISIBILITY_PRESET CXX_VISIBILITY_PRESET VISIBILITY_INLINES_HIDDEN)
 	# copy compile features
 	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
@@ -2835,22 +3004,32 @@ function (cotire_setup_unity_build_target _languages _configurations _target)
 		IMPLICIT_DEPENDS_INCLUDE_TRANSFORM RULE_LAUNCH_COMPILE RULE_LAUNCH_CUSTOM RULE_LAUNCH_LINK)
 	# copy Apple platform specific stuff
 	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
-		BUNDLE BUNDLE_EXTENSION FRAMEWORK INSTALL_NAME_DIR MACOSX_BUNDLE MACOSX_BUNDLE_INFO_PLIST
-		MACOSX_FRAMEWORK_INFO_PLIST MACOSX_RPATH OSX_ARCHITECTURES
-		OSX_ARCHITECTURES_<CONFIG> PRIVATE_HEADER PUBLIC_HEADER RESOURCE)
+		BUNDLE BUNDLE_EXTENSION FRAMEWORK FRAMEWORK_VERSION INSTALL_NAME_DIR
+		MACOSX_BUNDLE MACOSX_BUNDLE_INFO_PLIST MACOSX_FRAMEWORK_INFO_PLIST MACOSX_RPATH
+		OSX_ARCHITECTURES OSX_ARCHITECTURES_<CONFIG> PRIVATE_HEADER PUBLIC_HEADER RESOURCE XCTEST
+		IOS_INSTALL_COMBINED)
 	# copy Windows platform specific stuff
 	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
 		GNUtoMS
 		COMPILE_PDB_NAME COMPILE_PDB_NAME_<CONFIG>
 		COMPILE_PDB_OUTPUT_DIRECTORY COMPILE_PDB_OUTPUT_DIRECTORY_<CONFIG>
 		PDB_NAME PDB_NAME_<CONFIG> PDB_OUTPUT_DIRECTORY PDB_OUTPUT_DIRECTORY_<CONFIG>
-		VS_DOTNET_REFERENCES VS_GLOBAL_KEYWORD VS_GLOBAL_PROJECT_TYPES VS_GLOBAL_ROOTNAMESPACE
-		VS_KEYWORD VS_SCC_AUXPATH VS_SCC_LOCALPATH VS_SCC_PROJECTNAME VS_SCC_PROVIDER
-		VS_WINRT_EXTENSIONS VS_WINRT_REFERENCES VS_WINRT_COMPONENT
-		VS_DOTNET_TARGET_FRAMEWORK_VERSION WIN32_EXECUTABLE)
+		VS_DESKTOP_EXTENSIONS_VERSION VS_DOTNET_REFERENCES VS_DOTNET_TARGET_FRAMEWORK_VERSION
+		VS_GLOBAL_KEYWORD VS_GLOBAL_PROJECT_TYPES VS_GLOBAL_ROOTNAMESPACE
+		VS_IOT_EXTENSIONS_VERSION VS_IOT_STARTUP_TASK
+		VS_KEYWORD VS_MOBILE_EXTENSIONS_VERSION
+		VS_SCC_AUXPATH VS_SCC_LOCALPATH VS_SCC_PROJECTNAME VS_SCC_PROVIDER
+		VS_WINDOWS_TARGET_PLATFORM_MIN_VERSION
+		VS_WINRT_COMPONENT VS_WINRT_EXTENSIONS VS_WINRT_REFERENCES
+		WIN32_EXECUTABLE WINDOWS_EXPORT_ALL_SYMBOLS)
 	# copy Android platform specific stuff
 	cotire_copy_set_properites("${_configurations}" TARGET ${_target} ${_unityTargetName}
-		ANDROID_API ANDROID_API_MIN ANDROID_GUI)
+		ANDROID_API ANDROID_API_MIN ANDROID_GUI
+		ANDROID_ANT_ADDITIONAL_OPTIONS ANDROID_ARCH ANDROID_ASSETS_DIRECTORIES
+		ANDROID_JAR_DEPENDENCIES ANDROID_JAR_DIRECTORIES ANDROID_JAVA_SOURCE_DIR
+		ANDROID_NATIVE_LIB_DEPENDENCIES ANDROID_NATIVE_LIB_DIRECTORIES
+		ANDROID_PROCESS_MAX ANDROID_PROGUARD ANDROID_PROGUARD_CONFIG_PATH
+		ANDROID_SECURE_PROPS_PATH ANDROID_SKIP_ANT_STEP ANDROID_STL_TYPE)
 	# use output name from original target
 	get_target_property(_targetOutputName ${_unityTargetName} OUTPUT_NAME)
 	if (NOT _targetOutputName)
@@ -2880,10 +3059,16 @@ function (cotire_target _target)
 	if (NOT _option_CONFIGURATIONS)
 		cotire_get_configuration_types(_option_CONFIGURATIONS)
 	endif()
-	# trivial checks
-	get_target_property(_imported ${_target} IMPORTED)
-	if (_imported)
-		message (WARNING "cotire: imported target ${_target} cannot be cotired.")
+	# check if cotire can be applied to target at all
+	cotire_is_target_supported(${_target} _isSupported)
+	if (NOT _isSupported)
+		get_target_property(_imported ${_target} IMPORTED)
+		get_target_property(_targetType ${_target} TYPE)
+		if (_imported)
+			message (WARNING "cotire: imported ${_targetType} target ${_target} cannot be cotired.")
+		else()
+			message (STATUS "cotire: ${_targetType} target ${_target} cannot be cotired.")
+		endif()
 		return()
 	endif()
 	# resolve alias
@@ -2935,6 +3120,9 @@ function (cotire_target _target)
 	if (_targetUsePCH)
 		cotire_setup_target_pch_usage("${_targetLanguages}" ${_target} ${_wholeTarget} ${_cmds})
 		cotire_setup_pch_target("${_targetLanguages}" "${_option_CONFIGURATIONS}" ${_target})
+		if (_targetAddSCU)
+			cotire_setup_unity_target_pch_usage("${_targetLanguages}" ${_target})
+		endif()
 	endif()
 	get_target_property(_targetAddCleanTarget ${_target} COTIRE_ADD_CLEAN)
 	if (_targetAddCleanTarget)
@@ -2945,11 +3133,16 @@ endfunction(cotire_target)
 function (cotire_map_libraries _strategy _mappedLibrariesVar)
 	set (_mappedLibraries "")
 	foreach (_library ${ARGN})
-		if (TARGET "${_library}" AND "${_strategy}" MATCHES "COPY_UNITY")
-			# use target's corresponding unity target, if available
-			get_target_property(_libraryUnityTargetName ${_library} COTIRE_UNITY_TARGET_NAME)
-			if (TARGET "${_libraryUnityTargetName}")
-				list (APPEND _mappedLibraries "${_libraryUnityTargetName}")
+		if ("${_strategy}" MATCHES "COPY_UNITY")
+			cotire_is_target_supported(${_library} _isSupported)
+			if (_isSupported)
+				# use target's corresponding unity target, if available
+				get_target_property(_libraryUnityTargetName ${_library} COTIRE_UNITY_TARGET_NAME)
+				if (TARGET "${_libraryUnityTargetName}")
+					list (APPEND _mappedLibraries "${_libraryUnityTargetName}")
+				else()
+					list (APPEND _mappedLibraries "${_library}")
+				endif()
 			else()
 				list (APPEND _mappedLibraries "${_library}")
 			endif()
@@ -2962,6 +3155,10 @@ function (cotire_map_libraries _strategy _mappedLibrariesVar)
 endfunction()
 
 function (cotire_target_link_libraries _target)
+	cotire_is_target_supported(${_target} _isSupported)
+	if (NOT _isSupported)
+		return()
+	endif()
 	get_target_property(_unityTargetName ${_target} COTIRE_UNITY_TARGET_NAME)
 	if (TARGET "${_unityTargetName}")
 		get_target_property(_linkLibrariesStrategy ${_target} COTIRE_UNITY_LINK_LIBRARIES_INIT)
@@ -2998,7 +3195,7 @@ function (cotire_cleanup _binaryDir _cotireIntermediateDirName _targetName)
 	# filter files in intermediate directory
 	set (_filesToRemove "")
 	foreach (_file ${_cotireFiles})
-		get_filename_component(_dir "${_file}" PATH)
+		get_filename_component(_dir "${_file}" DIRECTORY)
 		get_filename_component(_dirName "${_dir}" NAME)
 		if ("${_dirName}" STREQUAL "${_cotireIntermediateDirName}")
 			list (APPEND _filesToRemove "${_file}")
@@ -3122,7 +3319,6 @@ if (CMAKE_SCRIPT_MODE_FILE)
 			message (STATUS "COTIRE_BUILD_TYPE=${COTIRE_BUILD_TYPE} not cotired (${COTIRE_TARGET_CONFIGURATION_TYPES})")
 		endif()
 		set (_sources "")
-		set (_sourceLocations "")
 		set (_sourcesDefinitions "")
 	endif()
 	set (_targetPreUndefs ${COTIRE_TARGET_PRE_UNDEFS})
@@ -3171,6 +3367,7 @@ if (CMAKE_SCRIPT_MODE_FILE)
 
 		cotire_generate_prefix_header(
 			"${COTIRE_ARGV3}" ${_files}
+			COMPILER_LAUNCHER "${COTIRE_TARGET_${COTIRE_TARGET_LANGUAGE}_COMPILER_LAUNCHER}"
 			COMPILER_EXECUTABLE "${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER}"
 			COMPILER_ARG1 ${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER_ARG1}
 			COMPILER_ID "${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER_ID}"
@@ -3180,7 +3377,6 @@ if (CMAKE_SCRIPT_MODE_FILE)
 			INCLUDE_PATH ${COTIRE_TARGET_INCLUDE_PATH}
 			IGNORE_EXTENSIONS "${CMAKE_${COTIRE_TARGET_LANGUAGE}_SOURCE_FILE_EXTENSIONS};${COTIRE_ADDITIONAL_PREFIX_HEADER_IGNORE_EXTENSIONS}"
 			INCLUDE_PRIORITY_PATH ${COTIRE_TARGET_INCLUDE_PRIORITY_PATH}
-			INCLUDE_SYSTEM_FLAG "${COTIRE_INCLUDE_SYSTEM_FLAG}"
 			INCLUDE_DIRECTORIES ${_includeDirs}
 			SYSTEM_INCLUDE_DIRECTORIES ${_systemIncludeDirs}
 			COMPILE_DEFINITIONS ${_compileDefinitions}
@@ -3198,12 +3394,12 @@ if (CMAKE_SCRIPT_MODE_FILE)
 
 		cotire_precompile_prefix_header(
 			"${COTIRE_ARGV3}" "${COTIRE_ARGV4}" "${COTIRE_ARGV5}"
+			COMPILER_LAUNCHER "${COTIRE_TARGET_${COTIRE_TARGET_LANGUAGE}_COMPILER_LAUNCHER}"
 			COMPILER_EXECUTABLE "${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER}"
 			COMPILER_ARG1 ${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER_ARG1}
 			COMPILER_ID "${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER_ID}"
 			COMPILER_VERSION "${CMAKE_${COTIRE_TARGET_LANGUAGE}_COMPILER_VERSION}"
 			LANGUAGE "${COTIRE_TARGET_LANGUAGE}"
-			INCLUDE_SYSTEM_FLAG "${COTIRE_INCLUDE_SYSTEM_FLAG}"
 			INCLUDE_DIRECTORIES ${_includeDirs}
 			SYSTEM_INCLUDE_DIRECTORIES ${_systemIncludeDirs}
 			COMPILE_DEFINITIONS ${_compileDefinitions}
@@ -3324,9 +3520,9 @@ else()
 	endif()
 	if (MSVC)
 		# MSVC default PCH memory scaling factor of 100 percent (75 MB) is too small for template heavy C++ code
-		# use a bigger default factor of 140 percent (105 MB)
+		# use a bigger default factor of 170 percent (128 MB)
 		if (NOT DEFINED COTIRE_PCH_MEMORY_SCALING_FACTOR)
-			set (COTIRE_PCH_MEMORY_SCALING_FACTOR "140")
+			set (COTIRE_PCH_MEMORY_SCALING_FACTOR "170")
 		endif()
 	endif()
 	if (NOT COTIRE_UNITY_BUILD_TARGET_SUFFIX)

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -120,6 +120,7 @@ set(PUPPET_COMMON_SOURCES
     src/runtime/types/hash.cc
     src/runtime/types/integer.cc
     src/runtime/types/iterable.cc
+    src/runtime/types/iterator.cc
     src/runtime/types/not_undef.cc
     src/runtime/types/numeric.cc
     src/runtime/types/optional.cc
@@ -137,6 +138,7 @@ set(PUPPET_COMMON_SOURCES
     src/runtime/values/array.cc
     src/runtime/values/defaulted.cc
     src/runtime/values/hash.cc
+    src/runtime/values/iterator.cc
     src/runtime/values/regex.cc
     src/runtime/values/type.cc
     src/runtime/values/undef.cc

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -119,6 +119,7 @@ set(PUPPET_COMMON_SOURCES
     src/runtime/types/floating.cc
     src/runtime/types/hash.cc
     src/runtime/types/integer.cc
+    src/runtime/types/iterable.cc
     src/runtime/types/not_undef.cc
     src/runtime/types/numeric.cc
     src/runtime/types/optional.cc

--- a/lib/include/puppet/runtime/types/integer.hpp
+++ b/lib/include/puppet/runtime/types/integer.hpp
@@ -49,13 +49,6 @@ namespace puppet { namespace runtime { namespace types {
         bool iterable() const;
 
         /**
-         * Gets the size of the range.
-         * If the range is not iterable, the size will be zero.
-         * @return Returns the size of the range.
-         */
-        size_t size() const;
-
-        /**
          * Calls the given callback for each integer in the range.
          * @param callback The callback to call.
          */

--- a/lib/include/puppet/runtime/types/integer.hpp
+++ b/lib/include/puppet/runtime/types/integer.hpp
@@ -43,14 +43,14 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
-         * Determines if the range is enumerable.
-         * @return Returns whether or not the range is enumerable.
+         * Determines if the range is iterable.
+         * @return Returns whether or not the range is iterable.
          */
-        bool enumerable() const;
+        bool iterable() const;
 
         /**
          * Gets the size of the range.
-         * If the range is not enumerable, the size will be zero.
+         * If the range is not iterable, the size will be zero.
          * @return Returns the size of the range.
          */
         size_t size() const;

--- a/lib/include/puppet/runtime/types/iterable.hpp
+++ b/lib/include/puppet/runtime/types/iterable.hpp
@@ -1,0 +1,109 @@
+/**
+ * @file
+ * Declares the Iterable type.
+ */
+#pragma once
+
+#include "../values/forward.hpp"
+#include <ostream>
+
+namespace puppet { namespace runtime { namespace types {
+
+    /**
+     * Represents the Puppet Iterable type.
+     */
+    struct iterable
+    {
+        /**
+         * Constructs an Iterable type.
+         * @param type The iterable value type.
+         */
+        explicit iterable(std::unique_ptr<values::type> type = nullptr);
+
+        /**
+         * Copy constructor for iterable type.
+         * @param other The other iterable type to copy from.
+         */
+        iterable(iterable const& other);
+
+        /**
+         * Move constructor for iterable type.
+         * Uses the default implementation.
+         */
+        iterable(iterable&&) noexcept = default;
+
+        /**
+         * Copy assignment operator for iterable type.
+         * @param other The other iterable type to copy assign from.
+         * @return Returns this iterable type.
+         */
+        iterable& operator=(iterable const& other);
+
+        /**
+         * Move assignment operator for iterable type.
+         * Uses the default implementation.
+         * @return Returns this iterable type.
+         */
+        iterable& operator=(iterable&&) noexcept = default;
+
+        /**
+         * Gets the iterable value type.
+         * @return Returns the iterable value type
+         */
+        std::unique_ptr<values::type> const& type() const;
+
+        /**
+         * Gets the name of the type.
+         * @return Returns the name of the type (i.e. Iterable).
+         */
+        static char const* name();
+
+        /**
+         * Determines if the given value is an instance of this type.
+         * @param value The value to determine if it is an instance of this type.
+         * @return Returns true if the given value is an instance of this type or false if not.
+         */
+        bool is_instance(values::value const& value) const;
+
+        /**
+         * Determines if the given type is a specialization (i.e. more specific) of this type.
+         * @param other The other type to check for specialization.
+         * @return Returns true if the other type is a specialization or false if not.
+         */
+        bool is_specialization(values::type const& other) const;
+
+     private:
+        std::unique_ptr<values::type> _type;
+    };
+
+    /**
+     * Stream insertion operator for iterable type.
+     * @param os The output stream to write the type to.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, iterable const&);
+
+    /**
+     * Equality operator for iterable.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two iterable types are equal or false if not.
+     */
+    bool operator==(iterable const& left, iterable const& right);
+
+    /**
+     * Inequality operator for iterable.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two iterable types are not equal or false if equal.
+     */
+    bool operator!=(iterable const& left, iterable const& right);
+
+    /**
+     * Hashes the iterable type.
+     * @param type The iterable type to hash.
+     * @return Returns the hash value for the type.
+     */
+    size_t hash_value(iterable const& type);
+
+}}}  // namespace puppet::runtime::types

--- a/lib/include/puppet/runtime/types/iterator.hpp
+++ b/lib/include/puppet/runtime/types/iterator.hpp
@@ -1,0 +1,109 @@
+/**
+ * @file
+ * Declares the Iterator type.
+ */
+#pragma once
+
+#include "../values/forward.hpp"
+#include <ostream>
+
+namespace puppet { namespace runtime { namespace types {
+
+    /**
+     * Represents the Puppet Iterator type.
+     */
+    struct iterator
+    {
+        /**
+         * Constructs an Iterator type.
+         * @param type The iterator value type.
+         */
+        explicit iterator(std::unique_ptr<values::type> type = nullptr);
+
+        /**
+         * Copy constructor for iterator type.
+         * @param other The other iterator type to copy from.
+         */
+        iterator(iterator const& other);
+
+        /**
+         * Move constructor for iterator type.
+         * Uses the default implementation.
+         */
+        iterator(iterator&&) noexcept = default;
+
+        /**
+         * Copy assignment operator for iterator type.
+         * @param other The other iterator type to copy assign from.
+         * @return Returns this iterator type.
+         */
+        iterator& operator=(iterator const& other);
+
+        /**
+         * Move assignment operator for iterator type.
+         * Uses the default implementation.
+         * @return Returns this iterator type.
+         */
+        iterator& operator=(iterator&&) noexcept = default;
+
+        /**
+         * Gets the iterator value type.
+         * @return Returns the iterator value type
+         */
+        std::unique_ptr<values::type> const& type() const;
+
+        /**
+         * Gets the name of the type.
+         * @return Returns the name of the type (i.e. Iterator).
+         */
+        static char const* name();
+
+        /**
+         * Determines if the given value is an instance of this type.
+         * @param value The value to determine if it is an instance of this type.
+         * @return Returns true if the given value is an instance of this type or false if not.
+         */
+        bool is_instance(values::value const& value) const;
+
+        /**
+         * Determines if the given type is a specialization (i.e. more specific) of this type.
+         * @param other The other type to check for specialization.
+         * @return Returns true if the other type is a specialization or false if not.
+         */
+        bool is_specialization(values::type const& other) const;
+
+     private:
+        std::unique_ptr<values::type> _type;
+    };
+
+    /**
+     * Stream insertion operator for iterator type.
+     * @param os The output stream to write the type to.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, iterator const&);
+
+    /**
+     * Equality operator for iterator.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two iterator types are equal or false if not.
+     */
+    bool operator==(iterator const& left, iterator const& right);
+
+    /**
+     * Inequality operator for iterator.
+     * @param left The left type to compare.
+     * @param right The right type to compare.
+     * @return Returns true if the two iterator types are not equal or false if equal.
+     */
+    bool operator!=(iterator const& left, iterator const& right);
+
+    /**
+     * Hashes the iterator type.
+     * @param type The iterator type to hash.
+     * @return Returns the hash value for the type.
+     */
+    size_t hash_value(iterator const& type);
+
+}}}  // namespace puppet::runtime::types

--- a/lib/include/puppet/runtime/values/hash.hpp
+++ b/lib/include/puppet/runtime/values/hash.hpp
@@ -56,8 +56,8 @@ namespace puppet { namespace runtime { namespace values {
 
         /**
          * The underlying sequence type.
-         * This is a list because the index keeps list references and they cannot be invalidated unless erased.
-         * This also provides for a faster erase implementation.
+         * This is a list because the hash index keeps list references and they cannot be invalidated unless erased.
+         * This also provides for a faster erase implementation than a deque could provide.
          */
         using sequence_type = std::list<pair>;
 

--- a/lib/include/puppet/runtime/values/iterator.hpp
+++ b/lib/include/puppet/runtime/values/iterator.hpp
@@ -1,0 +1,136 @@
+/**
+ * @file
+ * Declares the iterator runtime value.
+ */
+#pragma once
+
+#include "wrapper.hpp"
+#include "array.hpp"
+#include "hash.hpp"
+#include "regex.hpp"
+#include "type.hpp"
+#include <boost/variant.hpp>
+#include <ostream>
+#include <functional>
+
+namespace puppet { namespace runtime { namespace values {
+
+    /**
+     * Represents the iterator value.
+     */
+    struct iterator
+    {
+        /**
+         * The callback type for iterating over the iterator.
+         * The parameters to the callback are the optional key (nullptr if not iterating a hash) and value.
+         */
+        using callback_type = std::function<bool(values::value const*, values::value const&)>;
+
+        /**
+         * Constructs an iterator based off an iterable value.
+         * @param value The value being iterated.
+         * @param step The iterator step size.
+         * @param reverse True to reverse the iteration or false if not.
+         */
+        explicit iterator(wrapper<values::value> value, size_t step = 1, bool reverse = false);
+
+        /**
+        * Gets the underlying iterable value.
+        * This never returns an iterator, only an underlying value.
+        * @return Returns the underlying iterable value.
+        */
+        values::value const& value() const;
+
+        /**
+         * Gets the iterator's step count.
+         * @return Returns the iterator's step count.
+         */
+        size_t step() const;
+
+        /**
+         * Gets whether or not the iterator traverses in a reverse direction.
+         * @return Returns true if the direction is reverse or false if not.
+         */
+        bool reverse() const;
+
+        /**
+         * Iterates over the iterator.
+         * @param callback The callback to invoke for each iteration.
+         * @param reverse True to reverse the iteration or false otherwise.
+         */
+        void each(callback_type const& callback, bool reverse = false) const;
+
+     private:
+        wrapper<values::value> _value;
+        size_t _step;
+        bool _reverse;
+    };
+
+    /**
+     * Stream insertion operator for runtime iterator.
+     * @param os The output stream to write the runtime iterator to.
+     * @param iterator The runtime iterator to write.
+     * @return Returns the given output stream.
+     */
+    std::ostream& operator<<(std::ostream& os, values::iterator const& iterator);
+
+    /**
+     * Equality operator for iterator.
+     * @param left The left iterator to compare.
+     * @param right The right iterator to compare.
+     * @return Returns true if all elements of the iterator are equal or false if not.
+     */
+    bool operator==(iterator const& left, iterator const& right);
+
+    /**
+     * Inequality operator for iterator.
+     * @param left The left iterator to compare.
+     * @param right The right iterator to compare.
+     * @return Returns true if any elements of the iterators are not equal or false if all elements are equal.
+     */
+    bool operator!=(iterator const& left, iterator const& right);
+
+    /**
+     * Hashes the iterator value.
+     * @param iterator The iterator value to hash.
+     * @return Returns the hash value for the value.
+     */
+    size_t hash_value(values::iterator const& iterator);
+
+    /**
+     * Utility visitor for iteration.
+     */
+    struct iteration_visitor : boost::static_visitor<void>
+    {
+        /**
+         * Constructs an iteration visitor.
+         * @param callback The callback to invoke for each iteration.
+         * @param step The iteration step count.
+         * @param reverse True to reverse the iteration or false if not.
+         */
+        iteration_visitor(iterator::callback_type const& callback, size_t step = 1, bool reverse = false);
+
+     private:
+        template<class> friend class ::boost::detail::variant::invoke_visitor;
+
+        void operator()(undef const&) const;
+        void operator()(defaulted const&) const;
+        void operator()(int64_t value) const;
+        void operator()(double) const;
+        void operator()(bool) const;
+        void operator()(std::string const& value) const;
+        void operator()(values::regex const& value) const;
+        void operator()(values::type const& value) const;
+        void operator()(types::integer const& range) const;
+        void operator()(types::enumeration const& enumeration) const;
+        void operator()(variable const& value) const;
+        void operator()(values::array const& value) const;
+        void operator()(values::hash const& value) const;
+        void operator()(values::iterator const& value) const;
+
+        iterator::callback_type const& _callback;
+        size_t _step;
+        bool _reverse;
+    };
+
+}}}  // namespace puppet::runtime::values

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -18,6 +18,7 @@
 #include "../types/floating.hpp"
 #include "../types/hash.hpp"
 #include "../types/integer.hpp"
+#include "../types/iterable.hpp"
 #include "../types/not_undef.hpp"
 #include "../types/numeric.hpp"
 #include "../types/optional.hpp"
@@ -67,6 +68,7 @@ namespace puppet { namespace runtime { namespace values {
         types::floating,
         types::hash,
         types::integer,
+        types::iterable,
         types::not_undef,
         types::numeric,
         types::optional,

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -19,6 +19,7 @@
 #include "../types/hash.hpp"
 #include "../types/integer.hpp"
 #include "../types/iterable.hpp"
+#include "../types/iterator.hpp"
 #include "../types/not_undef.hpp"
 #include "../types/numeric.hpp"
 #include "../types/optional.hpp"
@@ -69,6 +70,7 @@ namespace puppet { namespace runtime { namespace values {
         types::hash,
         types::integer,
         types::iterable,
+        types::iterator,
         types::not_undef,
         types::numeric,
         types::optional,

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -8,6 +8,7 @@
 #include "array.hpp"
 #include "defaulted.hpp"
 #include "hash.hpp"
+#include "iterator.hpp"
 #include "regex.hpp"
 #include "type.hpp"
 #include "undef.hpp"
@@ -58,7 +59,8 @@ namespace puppet { namespace runtime { namespace values {
         type,
         variable,
         array,
-        hash
+        hash,
+        iterator
     >;
 
     /**
@@ -122,9 +124,9 @@ namespace puppet { namespace runtime { namespace values {
         value(char const* string);
 
         /**
-         * Intentionally undefined constructor to prevent implicit conversion to a boolean value.
+         * Intentionally deleted constructor to prevent implicit conversion to a boolean value.
          */
-        value(void const*);
+        value(void const*) = delete;
 
         /**
          * Move assigns the value given a wrapper containing the value to move.
@@ -340,20 +342,20 @@ namespace puppet { namespace runtime { namespace values {
     std::ostream& operator<<(std::ostream& os, value const& val);
 
     /**
-     * Declaration of operator== for values.
-     * This exists to intentionally cause an ambiguity if operator== is used on a value.
-     * Always use equals() on values and not operator==.
-     * @return No return defined.
+     * Equality operator for value.
+     * @param left The left value to compare.
+     * @param right The right value to compare.
+     * @return Returns true if the two values are equal or false if not.
      */
-    bool operator==(value const&, value const&);
+    bool operator==(value const& left, value const& right);
 
     /**
-     * Declaration of operator!= for values.
-     * This exists to intentionally cause an ambiguity if operator!= is used on a value.
-     * Always use !equals() on values and not operator!=.
-     * @return No return defined.
+     * Inequality operator for value.
+     * @param left The left value to compare.
+     * @param right The right value to compare.
+     * @return Returns true if the two values are not equal or false if they are equal.
      */
-    bool operator!=(value const&, value const&);
+    bool operator!=(value const& left, value const& right);
 
     /**
      * Equality visitor for values that handles variable comparison.
@@ -432,10 +434,11 @@ namespace puppet { namespace runtime { namespace values {
     }
 
     /**
-     * Enumerates each Unicode code point in the given string.
-     * @param str The string to enumerate.
+     * Iterates each Unicode code point in a string.
+     * @param str The string to iterate.
      * @param callback The callback to call for each Unicode code point, passed as a UTF-8 string.
+     * @param reverse True to reverse the iteration or false if not.
      */
-    void enumerate_string(std::string const& str, std::function<bool(std::string)> const& callback);
+    void each_code_point(std::string const& str, std::function<bool(std::string)> const& callback, bool reverse = false);
 
 }}}  // namespace puppet::runtime::values

--- a/lib/include/puppet/runtime/values/wrapper.hpp
+++ b/lib/include/puppet/runtime/values/wrapper.hpp
@@ -20,7 +20,7 @@ namespace puppet { namespace runtime { namespace values {
     struct wrapper
     {
         /**
-         * The t
+         * The underlying value type.
          */
         using value_type = T;
 

--- a/lib/include/puppet/runtime/values/wrapper.hpp
+++ b/lib/include/puppet/runtime/values/wrapper.hpp
@@ -343,6 +343,7 @@ namespace puppet { namespace runtime { namespace values {
     template <typename T>
     size_t hash_value(values::wrapper<T> const& wrapper)
     {
+        // Hash the underlying value
         return hash_value(*wrapper);
     }
 

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -239,6 +239,34 @@ namespace puppet { namespace compiler { namespace evaluation {
             return integer(from, to);
         }
 
+        value operator()(types::iterable const& target)
+        {
+            // Only 1 argument to Iterable
+            if (_arguments.size() > 1) {
+                throw evaluation_exception(
+                    (boost::format("expected 1 argument for %1% but %2% were given.") %
+                     types::iterable::name() %
+                     _arguments.size()
+                    ).str(),
+                    _contexts[2],
+                    _context.backtrace()
+                );
+            }
+
+            // First argument should be a type
+            if (!_arguments[0]->as<values::type>()) {
+                throw evaluation_exception(
+                    (boost::format("expected parameter to be %1% but found %2%.") %
+                     types::type::name() %
+                     _arguments[0]->get_type()
+                    ).str(),
+                    _contexts[0],
+                    _context.backtrace()
+                );
+            }
+            return types::iterable(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
+        }
+
         value operator()(floating const& target)
         {
             // At most 2 arguments to Float
@@ -979,6 +1007,16 @@ namespace puppet { namespace compiler { namespace evaluation {
                         );
                     }
                 }
+            }
+            if (from > to) {
+                throw evaluation_exception(
+                    (boost::format("a 'from' value of %1% cannot be greater than a 'to' value of %2%.") %
+                     from %
+                     to
+                    ).str(),
+                    _contexts[start_index],
+                    _context.backtrace()
+                );
             }
             return make_tuple(from, to);
         }

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -267,6 +267,34 @@ namespace puppet { namespace compiler { namespace evaluation {
             return types::iterable(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
         }
 
+        value operator()(types::iterator const& target)
+        {
+            // Only 1 argument to Iterator
+            if (_arguments.size() > 1) {
+                throw evaluation_exception(
+                    (boost::format("expected 1 argument for %1% but %2% were given.") %
+                     types::iterator::name() %
+                     _arguments.size()
+                    ).str(),
+                    _contexts[2],
+                    _context.backtrace()
+                );
+            }
+
+            // First argument should be a type
+            if (!_arguments[0]->as<values::type>()) {
+                throw evaluation_exception(
+                    (boost::format("expected parameter to be %1% but found %2%.") %
+                     types::type::name() %
+                     _arguments[0]->get_type()
+                    ).str(),
+                    _contexts[0],
+                    _context.backtrace()
+                );
+            }
+            return types::iterator(make_unique<values::type>(_arguments[0]->move_as<values::type>()));
+        }
+
         value operator()(floating const& target)
         {
             // At most 2 arguments to Float

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -199,6 +199,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             { types::hash::name(),          types::hash() },
             { types::integer::name(),       types::integer() },
             { types::iterable::name(),      types::iterable() },
+            { types::iterator::name(),      types::iterator() },
             { types::klass::name(),         types::klass() },
             { types::not_undef::name(),     types::not_undef() },
             { types::numeric::name(),       types::numeric() },
@@ -307,19 +308,19 @@ namespace puppet { namespace compiler { namespace evaluation {
                     continue;
                 }
 
-                // If splatted, unfold the array and match against each element
-                if (option_value.as<values::array>() && option.is_splat()) {
+                // Match against the value
+                if (is_match(result, expression, option_value, option.context())) {
+                    return evaluate_body(proposition.body);
+                }
+
+                // If splatted, match against each element in the array
+                if (option.is_splat() && option_value.as<values::array>()) {
                     auto array = option_value.move_as<values::array>();
                     for (auto& element : array) {
                         if (is_match(result, expression, element, option.context())) {
                             return evaluate_body(proposition.body);
                         }
                     }
-                }
-
-                // Otherwise, match against the value
-                if (is_match(result, expression, option_value, option.context())) {
-                    return evaluate_body(proposition.body);
                 }
             }
         }

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -198,6 +198,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             { types::floating::name(),      types::floating() },
             { types::hash::name(),          types::hash() },
             { types::integer::name(),       types::integer() },
+            { types::iterable::name(),      types::iterable() },
             { types::klass::name(),         types::klass() },
             { types::not_undef::name(),     types::not_undef() },
             { types::numeric::name(),       types::numeric() },

--- a/lib/src/compiler/evaluation/functions/call_context.cc
+++ b/lib/src/compiler/evaluation/functions/call_context.cc
@@ -108,8 +108,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             auto value = evaluator.evaluate(argument);
 
             // If the argument is being splatted, move its elements
-            if (argument.is_splat() && value.as<values::array>()) {
-                auto unfolded = value.move_as<values::array>();
+            if (argument.is_splat()) {
+                auto unfolded = value.to_array();
                 _argument_contexts.insert(_argument_contexts.end(), unfolded.size(), argument.context());
                 _arguments.reserve(_arguments.size() + unfolded.size());
                 _arguments.insert(_arguments.end(), std::make_move_iterator(unfolded.begin()), std::make_move_iterator(unfolded.end()));

--- a/lib/src/compiler/evaluation/functions/each.cc
+++ b/lib/src/compiler/evaluation/functions/each.cc
@@ -1,118 +1,47 @@
 #include <puppet/compiler/evaluation/functions/each.hpp>
 #include <puppet/compiler/evaluation/functions/call_context.hpp>
-#include <puppet/compiler/exceptions.hpp>
 #include <puppet/cast.hpp>
-#include <boost/format.hpp>
 
 using namespace std;
 using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
-    static void each_value(call_context& context, string const& argument)
-    {
-        values::array block_arguments(context.block()->parameters.size());
-
-        // Enumerate the string as Unicode codepoints
-        int64_t i = 0;
-        values::enumerate_string(argument, [&](string codepoint) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = codepoint;
-            } else {
-                block_arguments[0] = i++;
-                block_arguments[1] = codepoint;
-            }
-            context.yield(block_arguments);
-            return true;
-        });
-    }
-
-    static void each_value(call_context& context, types::integer const& range)
-    {
-        if (!range.iterable()) {
-            throw evaluation_exception(
-                (boost::format("%1% is not an iterable range.") %
-                 range
-                ).str(),
-                context.argument_context(0),
-                context.context().backtrace()
-            );
-        }
-
-        values::array block_arguments(context.block()->parameters.size());
-
-        range.each([&](int64_t index, int64_t value) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = value;
-            } else {
-                block_arguments[0] = index;
-                block_arguments[1] = value;
-            }
-            context.yield(block_arguments);
-            return true;
-        });
-    }
-
-    static void each_value(call_context& context, values::array const& argument)
-    {
-        values::array block_arguments(context.block()->parameters.size());
-
-        for (size_t i = 0; i < argument.size(); ++i) {
-            auto& element = argument[i];
-
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = element;
-            } else {
-                block_arguments[0] = static_cast<int64_t>(i);
-                block_arguments[1] = element;
-            }
-            context.yield(block_arguments);
-        }
-    }
-
-    static void each_value(call_context& context, values::hash const& argument)
-    {
-        values::array block_arguments(context.block()->parameters.size());
-
-        for (auto& kvp : argument) {
-            if (block_arguments.size() == 1) {
-                values::array pair(2);
-                pair[0] = kvp.key();
-                pair[1] = kvp.value();
-                block_arguments[0] = rvalue_cast(pair);
-            } else {
-                block_arguments[0] = kvp.key();
-                block_arguments[1] = kvp.value();
-            }
-            context.yield(block_arguments);
-        }
-    }
-
     descriptor each::create_descriptor()
     {
         functions::descriptor descriptor{ "each" };
 
-        descriptor.add("Callable[String, 1, 1, Callable[1, 2]]", [](call_context& context) {
-            each_value(context, context.argument(0).require<string>());
-            return rvalue_cast(context.argument(0));
-        });
-        descriptor.add("Callable[Integer, 1, 1, Callable[1, 2]]", [](call_context& context) -> values::value {
-            auto argument = context.argument(0).require<int64_t>();
-            if (argument > 0) {
-                each_value(context, types::integer{0, argument - 1});
-            }
-            return rvalue_cast(context.argument(0));
-        });
-        descriptor.add("Callable[Array[Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            each_value(context, context.argument(0).require<values::array>());
-            return rvalue_cast(context.argument(0));
-        });
-        descriptor.add("Callable[Hash[Any, Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            each_value(context, context.argument(0).require<values::hash>());
-            return rvalue_cast(context.argument(0));
-        });
-        descriptor.add("Callable[Type[Integer], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            each_value(context, boost::get<types::integer>(context.argument(0).require<values::type>()));
+        descriptor.add("Callable[Iterable, 1, 1, Callable[1, 2]]", [](call_context& context) {
+            values::array block_arguments(context.block()->parameters.size());
+            int64_t index = 0;
+
+            boost::apply_visitor(
+                values::iteration_visitor{
+                    [&](auto const* key, auto const& value) {
+                        if (key) {
+                            if (block_arguments.size() == 1) {
+                                values::array pair(2);
+                                pair[0] = *key;
+                                pair[1] = value;
+                                block_arguments[0] = rvalue_cast(pair);
+                            } else {
+                                block_arguments[0] = *key;
+                                block_arguments[1] = value;
+                            }
+                        } else {
+                            if (block_arguments.size() == 1) {
+                                block_arguments[0] = value;
+                            } else {
+                                block_arguments[0] = index++;
+                                block_arguments[1] = value;
+                            }
+                        }
+                        context.yield(block_arguments);
+                        return true;
+                    }
+                },
+                context.argument(0)
+            );
             return rvalue_cast(context.argument(0));
         });
         return descriptor;

--- a/lib/src/compiler/evaluation/functions/each.cc
+++ b/lib/src/compiler/evaluation/functions/each.cc
@@ -29,9 +29,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
     static void each_value(call_context& context, types::integer const& range)
     {
-        if (!range.enumerable()) {
+        if (!range.iterable()) {
             throw evaluation_exception(
-                (boost::format("%1% is not enumerable.") %
+                (boost::format("%1% is not an iterable range.") %
                  range
                 ).str(),
                 context.argument_context(0),

--- a/lib/src/compiler/evaluation/functions/filter.cc
+++ b/lib/src/compiler/evaluation/functions/filter.cc
@@ -1,106 +1,39 @@
 #include <puppet/compiler/evaluation/functions/filter.hpp>
 #include <puppet/compiler/evaluation/functions/call_context.hpp>
-#include <puppet/compiler/exceptions.hpp>
-#include <boost/format.hpp>
 
 using namespace std;
 using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
-    static values::value filter_values(call_context& context, string const& argument)
+    static values::hash iterate_hash(call_context& context)
     {
-        values::array result;
         values::array block_arguments(context.block()->parameters.size());
-
-        // Enumerate the string as Unicode codepoints
-        int64_t i = 0;
-        values::enumerate_string(argument, [&](string codepoint) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = codepoint;
-            } else {
-                block_arguments[0] = i++;
-                block_arguments[1] = codepoint;
-            }
-            if (context.yield(block_arguments).is_true()) {
-                result.emplace_back(rvalue_cast(codepoint));
-            }
-            return true;
-        });
-
-        return result;
-    }
-
-    static values::value filter_values(call_context& context, types::integer const& range)
-    {
-        if (!range.iterable()) {
-            throw evaluation_exception(
-                (boost::format("%1% is not an iterable range.") %
-                 range
-                ).str(),
-                context.argument_context(0),
-                context.context().backtrace()
-            );
-        }
-
-        values::array result;
-        values::array block_arguments(context.block()->parameters.size());
-
-        range.each([&](int64_t index, int64_t value) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = value;
-            } else {
-                block_arguments[0] = index;
-                block_arguments[1] = value;
-            }
-            if (context.yield(block_arguments).is_true()) {
-                result.emplace_back(value);
-            }
-            return true;
-        });
-        return result;
-    }
-
-    static values::value filter_values(call_context& context, values::array const& argument)
-    {
-        values::array result;
-        values::array block_arguments(context.block()->parameters.size());
-
-        for (size_t i = 0; i < argument.size(); ++i) {
-            auto& element = argument[i];
-
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = element;
-            } else {
-                block_arguments[0] = static_cast<int64_t>(i);
-                block_arguments[1] = element;
-            }
-            if (context.yield(block_arguments).is_true()) {
-                result.emplace_back(element);
-            }
-        }
-        return result;
-    }
-
-    static values::value filter_values(call_context& context, values::hash const& argument)
-    {
         values::hash result;
-        values::array block_arguments(context.block()->parameters.size());
 
-        for (auto& kvp : argument) {
-            if (block_arguments.size() == 1) {
-                values::array pair(2);
-                pair[0] = kvp.key();
-                pair[1] = kvp.value();
-                block_arguments[0] = rvalue_cast(pair);
-            } else {
-                block_arguments[0] = kvp.key();
-                block_arguments[1] = kvp.value();
-            }
-            if (context.yield(block_arguments).is_true()) {
-                result.set(kvp.key(), kvp.value());
-            }
-        }
+        boost::apply_visitor(
+            values::iteration_visitor{
+                [&](auto const* key, auto const& value) {
+                    if (!key) {
+                        throw runtime_error("expected a key.");
+                    }
+                    if (block_arguments.size() == 1) {
+                        values::array pair(2);
+                        pair[0] = *key;
+                        pair[1] = value;
+                        block_arguments[0] = rvalue_cast(pair);
+                    } else {
+                        block_arguments[0] = *key;
+                        block_arguments[1] = value;
+                    }
+                    if (context.yield(block_arguments).is_true()) {
+                        result.set(*key, value);
+                    }
+                    return true;
+                }
+            },
+            context.argument(0)
+        );
         return result;
     }
 
@@ -108,26 +41,43 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
     {
         functions::descriptor descriptor{ "filter" };
 
-        descriptor.add("Callable[String, 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return filter_values(context, context.argument(0).require<string>());
-        });
-        descriptor.add("Callable[Integer, 1, 1, Callable[1, 2]]", [](call_context& context) -> values::value {
-            auto argument = context.argument(0).require<int64_t>();
-            if (argument <= 0) {
-                return values::array();
+        descriptor.add("Callable[Iterable, 1, 1, Callable[1, 2]]", [](call_context& context) -> values::value {
+
+            // If a hash or iterating a hash, return a hash
+            if (context.argument(0).as<values::hash>()) {
+                return iterate_hash(context);
             }
-            return filter_values(context, types::integer{ 0, argument });
-        });
-        descriptor.add("Callable[Array[Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return filter_values(context, context.argument(0).require<values::array>());
-        });
-        descriptor.add("Callable[Hash[Any, Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return filter_values(context, context.argument(0).require<values::hash>());
-        });
-        descriptor.add("Callable[Type[Integer], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            auto& argument = context.argument(0).require<values::type>();
-            auto& range = boost::get<types::integer>(argument);
-            return filter_values(context, range);
+            if (auto iterator = context.argument(0).as<values::iterator>()) {
+                if (iterator->value().as<values::hash>()) {
+                    return iterate_hash(context);
+                }
+            }
+
+            values::array block_arguments(context.block()->parameters.size());
+            int64_t index = 0;
+            values::array result;
+
+            boost::apply_visitor(
+                values::iteration_visitor{
+                    [&](auto const* key, auto const& value) {
+                        if (key) {
+                            throw runtime_error("expected a null key.");
+                        }
+                        if (block_arguments.size() == 1) {
+                            block_arguments[0] = value;
+                        } else {
+                            block_arguments[0] = index++;
+                            block_arguments[1] = value;
+                        }
+                        if (context.yield(block_arguments).is_true()) {
+                            result.emplace_back(value);
+                        }
+                        return true;
+                    }
+                },
+                context.argument(0)
+            );
+            return result;
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/functions/filter.cc
+++ b/lib/src/compiler/evaluation/functions/filter.cc
@@ -33,9 +33,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
     static values::value filter_values(call_context& context, types::integer const& range)
     {
-        if (!range.enumerable()) {
+        if (!range.iterable()) {
             throw evaluation_exception(
-                (boost::format("%1% is not enumerable.") %
+                (boost::format("%1% is not an iterable range.") %
                  range
                 ).str(),
                 context.argument_context(0),

--- a/lib/src/compiler/evaluation/functions/map.cc
+++ b/lib/src/compiler/evaluation/functions/map.cc
@@ -1,133 +1,48 @@
 #include <puppet/compiler/evaluation/functions/map.hpp>
 #include <puppet/compiler/evaluation/functions/call_context.hpp>
-#include <puppet/compiler/exceptions.hpp>
-#include <boost/format.hpp>
 
 using namespace std;
 using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
-    static values::value map_values(call_context& context, string const& argument)
-    {
-        values::array result;
-        result.reserve(argument.size());
-
-        values::array block_arguments(context.block()->parameters.size());
-
-        // Enumerate the string as Unicode codepoints
-        int64_t i = 0;
-        values::enumerate_string(argument, [&](string codepoint) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = codepoint;
-            } else {
-                block_arguments[0] = i++;
-                block_arguments[1] = codepoint;
-            }
-            result.emplace_back(context.yield(block_arguments));
-            return true;
-        });
-
-        return result;
-    }
-
-    static values::value map_values(call_context& context, types::integer const& range)
-    {
-        if (!range.iterable()) {
-            throw evaluation_exception(
-                (boost::format("%1% is not an iterable range.") %
-                 range
-                ).str(),
-                context.argument_context(0),
-                context.context().backtrace()
-            );
-        }
-
-        values::array result;
-        result.reserve(range.size());
-
-        values::array block_arguments(context.block()->parameters.size());
-
-        range.each([&](int64_t index, int64_t value) {
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = value;
-            } else {
-                block_arguments[0] = index;
-                block_arguments[1] = value;
-            }
-            result.emplace_back(context.yield(block_arguments));
-            return true;
-        });
-        return result;
-    }
-
-    static values::value map_values(call_context& context, values::array const& argument)
-    {
-        values::array result;
-        result.reserve(argument.size());
-
-        values::array block_arguments(context.block()->parameters.size());
-
-        for (size_t i = 0; i < argument.size(); ++i) {
-            auto& element = argument[i];
-
-            if (block_arguments.size() == 1) {
-                block_arguments[0] = element;
-            } else {
-                block_arguments[0] = static_cast<int64_t>(i);
-                block_arguments[1] = element;
-            }
-            result.emplace_back(context.yield(block_arguments));
-        }
-        return result;
-    }
-
-    static values::value map_values(call_context& context, values::hash const& argument)
-    {
-        values::array result;
-        result.reserve(argument.size());
-
-        values::array block_arguments(context.block()->parameters.size());
-
-        for (auto& kvp : argument) {
-            if (block_arguments.size() == 1) {
-                values::array pair(2);
-                pair[0] = kvp.key();
-                pair[1] = kvp.value();
-                block_arguments[0] = rvalue_cast(pair);
-            } else {
-                block_arguments[0] = kvp.key();
-                block_arguments[1] = kvp.value();
-            }
-            result.emplace_back(context.yield(block_arguments));
-        }
-        return result;
-    }
-
     descriptor map::create_descriptor()
     {
         functions::descriptor descriptor{ "map" };
 
-        descriptor.add("Callable[String, 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return map_values(context, context.argument(0).require<string>());
-        });
-        descriptor.add("Callable[Integer, 1, 1, Callable[1, 2]]", [](call_context& context) -> values::value {
-            auto argument = context.argument(0).require<int64_t>();
-            if (argument <= 0) {
-                return values::array();
-            }
-            return map_values(context, types::integer{ 0, argument - 1 });
-        });
-        descriptor.add("Callable[Array[Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return map_values(context, context.argument(0).require<values::array>());
-        });
-        descriptor.add("Callable[Hash[Any, Any], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            return map_values(context, context.argument(0).require<values::hash>());
-        });
-        descriptor.add("Callable[Type[Integer], 1, 1, Callable[1, 2]]", [](call_context& context) {
-            auto& argument = context.argument(0).require<values::type>();
-            auto& range = boost::get<types::integer>(argument);
-            return map_values(context, range);
+        descriptor.add("Callable[Iterable, 1, 1, Callable[1, 2]]", [](call_context& context) {
+            values::array block_arguments(context.block()->parameters.size());
+            int64_t index = 0;
+            values::array result;
+
+            boost::apply_visitor(
+                values::iteration_visitor{
+                    [&](auto const* key, auto const& value) {
+                        if (key) {
+                            if (block_arguments.size() == 1) {
+                                values::array pair(2);
+                                pair[0] = *key;
+                                pair[1] = value;
+                                block_arguments[0] = rvalue_cast(pair);
+                            } else {
+                                block_arguments[0] = *key;
+                                block_arguments[1] = value;
+                            }
+                        } else {
+                            if (block_arguments.size() == 1) {
+                                block_arguments[0] = value;
+                            } else {
+                                block_arguments[0] = index++;
+                                block_arguments[1] = value;
+                            }
+                        }
+                        result.emplace_back(context.yield(block_arguments));
+                        return true;
+                    }
+                },
+                context.argument(0)
+            );
+            return result;
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/functions/map.cc
+++ b/lib/src/compiler/evaluation/functions/map.cc
@@ -33,9 +33,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
     static values::value map_values(call_context& context, types::integer const& range)
     {
-        if (!range.enumerable()) {
+        if (!range.iterable()) {
             throw evaluation_exception(
-                (boost::format("%1% is not enumerable.") %
+                (boost::format("%1% is not an iterable range.") %
                  range
                 ).str(),
                 context.argument_context(0),

--- a/lib/src/compiler/evaluation/functions/reduce.cc
+++ b/lib/src/compiler/evaluation/functions/reduce.cc
@@ -1,7 +1,5 @@
 #include <puppet/compiler/evaluation/functions/reduce.hpp>
 #include <puppet/compiler/evaluation/functions/call_context.hpp>
-#include <puppet/compiler/exceptions.hpp>
-#include <boost/format.hpp>
 #include <boost/optional.hpp>
 
 using namespace std;
@@ -9,146 +7,52 @@ using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
-    static values::value reduce_values(call_context& context, boost::optional<values::value> memo, string const& argument)
-    {
-        values::array block_arguments(2);
-
-        // Enumerate the string as Unicode codepoints
-        values::enumerate_string(argument, [&](string codepoint) {
-            // If no memo, set it now
-            if (!memo) {
-                memo.emplace(rvalue_cast(codepoint));
-                return true;
-            }
-
-            block_arguments[0] = rvalue_cast(*memo);
-            block_arguments[1] = rvalue_cast(codepoint);
-            memo.emplace(context.yield(block_arguments));
-            return true;
-        });
-
-        if (memo) {
-            return rvalue_cast(*memo);
-        }
-        return values::undef();
-    }
-
-    static values::value reduce_values(call_context& context, boost::optional<values::value> memo, types::integer const& range)
-    {
-        if (!range.iterable()) {
-            throw evaluation_exception(
-                (boost::format("%1% is not an iterable range.") %
-                 range
-                ).str(),
-                context.argument_context(0),
-                context.context().backtrace()
-            );
-        }
-
-        values::array block_arguments(2);
-
-        range.each([&](int64_t index, int64_t value) {
-            // If no memo, set it now
-            if (!memo) {
-                memo = value;
-                return true;
-            }
-
-            block_arguments[0] = rvalue_cast(*memo);
-            block_arguments[1] = value;
-            memo.emplace(context.yield(block_arguments));
-            return true;
-        });
-
-        if (memo) {
-            return rvalue_cast(*memo);
-        }
-        return values::undef();
-    }
-
-    static values::value reduce_values(call_context& context, boost::optional<values::value> memo, values::array const& argument)
-    {
-        values::array block_arguments(2);
-
-        for (size_t i = 0; i < argument.size(); ++i) {
-            auto& element = argument[i];
-
-            // If no memo, set it now
-            if (!memo) {
-                memo = element;
-                continue;
-            }
-
-            block_arguments[0] = rvalue_cast(*memo);
-            block_arguments[1] = element;
-            memo.emplace(context.yield(block_arguments));
-        }
-
-        if (memo) {
-            return rvalue_cast(*memo);
-        }
-        return values::undef();
-    }
-
-    static values::value reduce_values(call_context& context, boost::optional<values::value> memo, values::hash const& argument)
-    {
-        values::array block_arguments(2);
-
-        for (auto& kvp : argument) {
-            values::array pair(2);
-            pair[0] = kvp.key();
-            pair[1] = kvp.value();
-
-            // If no memo, set it now
-            if (!memo) {
-                memo.emplace(rvalue_cast(pair));
-                continue;
-            }
-
-            block_arguments[0] = rvalue_cast(*memo);
-            block_arguments[1] = rvalue_cast(pair);
-            memo.emplace(context.yield(block_arguments));
-        }
-
-        if (memo) {
-            return rvalue_cast(*memo);
-        }
-        return values::undef();
-    }
-
     descriptor reduce::create_descriptor()
     {
         functions::descriptor descriptor{ "reduce" };
 
-        // Utility function for extracting the memo
-        auto static const extract_memo = [](call_context& context) -> boost::optional<values::value> {
-            if (context.arguments().size() < 2) {
-                return boost::none;
-            }
-            return rvalue_cast(context.argument(1));
-        };
+        descriptor.add("Callable[Iterable, Any, 1, 2, Callable[2, 2]]", [](call_context& context) -> values::value {
+            values::array block_arguments(context.block()->parameters.size());
 
-        descriptor.add("Callable[String, Any, 1, 2, Callable[2, 2]]", [&](call_context& context) {
-            return reduce_values(context, extract_memo(context), context.argument(0).require<string>());
-        });
-        descriptor.add("Callable[Integer, Any, 1, 2, Callable[2, 2]]", [&](call_context& context) -> values::value {
-            auto argument = context.argument(0).require<int64_t>();
-            if (argument <= 0) {
-                return values::undef();
+            boost::optional<values::value> memo;
+            if (context.arguments().size() == 2) {
+                memo = rvalue_cast(context.argument(1));
             }
-            return reduce_values(context, extract_memo(context), types::integer{ 0, argument - 1 });
+
+            boost::apply_visitor(
+                values::iteration_visitor{
+                    [&](auto const* key, auto const& value) {
+                        if (key) {
+                            values::array pair(2);
+                            pair[0] = *key;
+                            pair[1] = value;
+
+                            if (!memo) {
+                                memo.emplace(rvalue_cast(pair));
+                                return true;
+                            }
+                            block_arguments[1] = rvalue_cast(pair);
+                        } else {
+                            if (!memo) {
+                                memo = value;
+                                return true;
+                            }
+                            block_arguments[1] = value;
+                        }
+                        block_arguments[0] = rvalue_cast(*memo);
+                        memo.emplace(context.yield(block_arguments));
+                        return true;
+                    }
+                },
+                context.argument(0)
+            );
+
+            if (memo) {
+                return rvalue_cast(*memo);
+            }
+            return values::undef();
         });
-        descriptor.add("Callable[Array[Any], Any, 1, 2, Callable[2, 2]]", [&](call_context& context) {
-            return reduce_values(context, extract_memo(context), context.argument(0).require<values::array>());
-        });
-        descriptor.add("Callable[Hash[Any, Any], Any, 1, 2, Callable[2, 2]]", [&](call_context& context) {
-            return reduce_values(context, extract_memo(context), context.argument(0).require<values::hash>());
-        });
-        descriptor.add("Callable[Type[Integer], Any, 1, 2, Callable[2, 2]]", [&](call_context& context) {
-            auto& argument = context.argument(0).require<values::type>();
-            auto& range = boost::get<types::integer>(argument);
-            return reduce_values(context, extract_memo(context), range);
-        });
+
         return descriptor;
     }
 

--- a/lib/src/compiler/evaluation/functions/reduce.cc
+++ b/lib/src/compiler/evaluation/functions/reduce.cc
@@ -35,9 +35,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
     static values::value reduce_values(call_context& context, boost::optional<values::value> memo, types::integer const& range)
     {
-        if (!range.enumerable()) {
+        if (!range.iterable()) {
             throw evaluation_exception(
-                (boost::format("%1% is not enumerable.") %
+                (boost::format("%1% is not an iterable range.") %
                  range
                 ).str(),
                 context.argument_context(0),

--- a/lib/src/compiler/evaluation/functions/split.cc
+++ b/lib/src/compiler/evaluation/functions/split.cc
@@ -11,7 +11,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
     static values::value split_characters(string const& str)
     {
         values::array result;
-        values::enumerate_string(str, [&](string codepoint) {
+        values::each_code_point(str, [&](string codepoint) {
             result.emplace_back(rvalue_cast(codepoint));
             return true;
         });

--- a/lib/src/runtime/types/integer.cc
+++ b/lib/src/runtime/types/integer.cc
@@ -26,7 +26,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Integer";
     }
 
-    bool integer::enumerable() const
+    bool integer::iterable() const
     {
         return std::min(_from, _to) != numeric_limits<int64_t>::min() &&
                std::max(_from, _to) != numeric_limits<int64_t>::max();
@@ -34,7 +34,7 @@ namespace puppet { namespace runtime { namespace types {
 
     size_t integer::size() const
     {
-        if (!enumerable()) {
+        if (!iterable()) {
             return 0;
         }
         // Ranges are inclusive, so size is always > 0
@@ -43,7 +43,7 @@ namespace puppet { namespace runtime { namespace types {
 
     void integer::each(function<bool(int64_t, int64_t)> const& callback) const
     {
-        if (!callback || !enumerable()) {
+        if (!callback || !iterable()) {
             return;
         }
 

--- a/lib/src/runtime/types/integer.cc
+++ b/lib/src/runtime/types/integer.cc
@@ -9,6 +9,9 @@ namespace puppet { namespace runtime { namespace types {
         _from(from),
         _to(to)
     {
+        if (from > to) {
+            throw runtime_error("from cannot be greater than to.");
+        }
     }
 
     int64_t integer::from() const
@@ -28,17 +31,7 @@ namespace puppet { namespace runtime { namespace types {
 
     bool integer::iterable() const
     {
-        return std::min(_from, _to) != numeric_limits<int64_t>::min() &&
-               std::max(_from, _to) != numeric_limits<int64_t>::max();
-    }
-
-    size_t integer::size() const
-    {
-        if (!iterable()) {
-            return 0;
-        }
-        // Ranges are inclusive, so size is always > 0
-        return std::max(_from, _to) - std::min(_from, _to) + 1;
+        return _from != numeric_limits<int64_t>::min() && _to != numeric_limits<int64_t>::max();
     }
 
     void integer::each(function<bool(int64_t, int64_t)> const& callback) const

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -101,7 +101,31 @@ namespace puppet { namespace runtime { namespace types {
             return false;
         }
 
-        // TODO: add support for Iterator
+        // Check for iterator
+        if (auto iterator = value.as<values::iterator>()) {
+            bool match = true;
+            if (_type) {
+                auto tuple = boost::get<types::tuple>(_type.get());
+                iterator->each([&](auto const* key, auto const& value) {
+                    if (key) {
+                        if (!tuple) {
+                            match = false;
+                            return false;
+                        }
+                        auto& types = tuple->types();
+                        if (types.size() != 2) {
+                            match = false;
+                            return false;
+                        }
+                        match = types[0]->is_instance(*key) && types[1]->is_instance(value);
+                    } else {
+                        match = _type->is_instance(value);
+                    }
+                    return match;
+                });
+            }
+            return match;
+        }
         return false;
     }
 

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -1,0 +1,156 @@
+#include <puppet/runtime/values/value.hpp>
+#include <boost/functional/hash.hpp>
+
+using namespace std;
+
+namespace puppet { namespace runtime { namespace types {
+
+    iterable::iterable(unique_ptr<values::type> type) :
+        _type(rvalue_cast(type))
+    {
+    }
+
+    iterable::iterable(iterable const& other) :
+        _type(other.type() ? new values::type(*other.type()) : nullptr)
+    {
+    }
+
+    iterable& iterable::operator=(iterable const& other)
+    {
+        _type.reset(other.type() ? new values::type(*other.type()) : nullptr);
+        return *this;
+    }
+
+    unique_ptr<values::type> const& iterable::type() const
+    {
+        return _type;
+    }
+
+    char const* iterable::name()
+    {
+        return "Iterable";
+    }
+
+    bool iterable::is_instance(values::value const& value) const
+    {
+        // Check for array
+        if (auto array = value.as<values::array>()) {
+            if (_type) {
+                for (auto& element : *array) {
+                    if (!_type->is_instance(*element)) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Check for hash
+        if (auto hash = value.as<values::hash>()) {
+            if (_type) {
+                auto tuple = boost::get<types::tuple>(_type.get());
+                if (!tuple) {
+                    return false;
+                }
+
+                auto& types = tuple->types();
+                if (types.size() != 2) {
+                    return false;
+                }
+
+                // Check that all the keys and values are instances of the tuple
+                for (auto& kvp : *hash) {
+                    if (!types[0]->is_instance(kvp.key())) {
+                        return false;
+                    }
+                    if (!types[1]->is_instance(kvp.value())) {
+                        return false;
+                    }
+                }
+            }
+            return true;
+        }
+
+        // Check for an integral value
+        if (auto integer = value.as<int64_t>()) {
+            if (_type) {
+                // Check for Integer[0, N-1]
+                auto type = boost::get<types::integer>(_type.get());
+                if (!type || type->from() != 0 || type->to() != (*integer - 1)) {
+                    return false;
+                }
+            }
+            return *integer >= 0;
+        }
+
+        // Check for type
+        if (auto type = value.as<values::type>()) {
+            if (_type && *_type != *type) {
+                return false;
+            }
+
+            // Check for Integer
+            if (auto integer = boost::get<types::integer>(type)) {
+                return integer->iterable();
+            }
+
+            // Check for Enum
+            if (boost::get<types::enumeration>(type)) {
+                return true;
+            }
+            return false;
+        }
+
+        // TODO: add support for Iterator
+        return false;
+    }
+
+    bool iterable::is_specialization(values::type const& other) const
+    {
+        // If this iterable has a specialization, the other iterable cannot be a specialization
+        if (_type) {
+            return false;
+        }
+        // Check that the other iterable is specialized
+        auto iterable = boost::get<types::iterable>(&other);
+        return iterable && iterable->type();
+    }
+
+    ostream& operator<<(ostream& os, types::iterable const& type)
+    {
+        os << types::iterable::name();
+        if (!type.type()) {
+            return os;
+        }
+        os << '[' << *type.type() << ']';
+        return os;
+    }
+
+    bool operator==(iterable const& left, iterable const& right)
+    {
+        if (!left.type() && !right.type()) {
+            return true;
+        } else if (left.type() || right.type()) {
+            return false;
+        }
+        return *left.type() == *right.type();
+    }
+
+    bool operator!=(iterable const& left, iterable const& right)
+    {
+        return !(left == right);
+    }
+
+    size_t hash_value(types::iterable const& type)
+    {
+        static const size_t name_hash = boost::hash_value(types::iterable::name());
+
+        size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        if (type.type()) {
+            boost::hash_combine(seed, *type.type());
+        }
+        return seed;
+    }
+
+}}}  // namespace puppet::runtime::types

--- a/lib/src/runtime/types/iterator.cc
+++ b/lib/src/runtime/types/iterator.cc
@@ -1,0 +1,113 @@
+#include <puppet/runtime/values/value.hpp>
+#include <boost/functional/hash.hpp>
+
+using namespace std;
+
+namespace puppet { namespace runtime { namespace types {
+
+    iterator::iterator(unique_ptr<values::type> type) :
+        _type(rvalue_cast(type))
+    {
+    }
+
+    iterator::iterator(iterator const& other) :
+        _type(other.type() ? new values::type(*other.type()) : nullptr)
+    {
+    }
+
+    iterator& iterator::operator=(iterator const& other)
+    {
+        _type.reset(other.type() ? new values::type(*other.type()) : nullptr);
+        return *this;
+    }
+
+    unique_ptr<values::type> const& iterator::type() const
+    {
+        return _type;
+    }
+
+    char const* iterator::name()
+    {
+        return "Iterator";
+    }
+
+    bool iterator::is_instance(values::value const& value) const
+    {
+        auto iterator = value.as<values::iterator>();
+        if (!iterator) {
+            return false;
+        }
+
+        bool match = true;
+        if (_type) {
+            auto tuple = boost::get<types::tuple>(_type.get());
+            iterator->each([&](auto const* key, auto const& value) {
+                if (key) {
+                    if (!tuple) {
+                        match = false;
+                        return false;
+                    }
+                    auto& types = tuple->types();
+                    if (types.size() != 2) {
+                        match = false;
+                        return false;
+                    }
+                    match = types[0]->is_instance(*key) && types[1]->is_instance(value);
+                } else {
+                    match = _type->is_instance(value);
+                }
+                return match;
+            });
+        }
+        return match;
+    }
+
+    bool iterator::is_specialization(values::type const& other) const
+    {
+        // If this iterator has a specialization, the other iterator cannot be a specialization
+        if (_type) {
+            return false;
+        }
+        // Check that the other iterator is specialized
+        auto iterator = boost::get<types::iterator>(&other);
+        return iterator && iterator->type();
+    }
+
+    ostream& operator<<(ostream& os, types::iterator const& type)
+    {
+        os << types::iterator::name();
+        if (!type.type()) {
+            return os;
+        }
+        os << '[' << *type.type() << ']';
+        return os;
+    }
+
+    bool operator==(iterator const& left, iterator const& right)
+    {
+        if (!left.type() && !right.type()) {
+            return true;
+        } else if (left.type() || right.type()) {
+            return false;
+        }
+        return *left.type() == *right.type();
+    }
+
+    bool operator!=(iterator const& left, iterator const& right)
+    {
+        return !(left == right);
+    }
+
+    size_t hash_value(types::iterator const& type)
+    {
+        static const size_t name_hash = boost::hash_value(types::iterator::name());
+
+        size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        if (type.type()) {
+            boost::hash_combine(seed, *type.type());
+        }
+        return seed;
+    }
+
+}}}  // namespace puppet::runtime::types

--- a/lib/src/runtime/values/array.cc
+++ b/lib/src/runtime/values/array.cc
@@ -54,8 +54,10 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::array const& array)
     {
-        std::size_t seed = 0;
+        static const size_t name_hash = boost::hash_value("array");
 
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
         for (auto const& element : array) {
             boost::hash_combine(seed, element);
         }

--- a/lib/src/runtime/values/defaulted.cc
+++ b/lib/src/runtime/values/defaulted.cc
@@ -22,7 +22,11 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(defaulted const&)
     {
-        return 0;
+        static const size_t name_hash = boost::hash_value("default");
+
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        return seed;
     }
 
 }}}  // namespace puppet::runtime::values

--- a/lib/src/runtime/values/hash.cc
+++ b/lib/src/runtime/values/hash.cc
@@ -206,8 +206,10 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::hash const& hash)
     {
-        std::size_t seed = 0;
+        static const size_t name_hash = boost::hash_value("hash");
 
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
         for (auto const& element : hash) {
             boost::hash_combine(seed, element.key());
             boost::hash_combine(seed, element.value());

--- a/lib/src/runtime/values/iterator.cc
+++ b/lib/src/runtime/values/iterator.cc
@@ -1,0 +1,275 @@
+#include <puppet/runtime/values/value.hpp>
+#include <puppet/cast.hpp>
+
+using namespace std;
+
+namespace puppet { namespace runtime { namespace values {
+
+    iterator::iterator(wrapper<values::value> value, size_t step, bool reverse) :
+        _value(rvalue_cast(value)),
+        _step(step),
+        _reverse(reverse)
+    {
+        if (_step == 0) {
+            throw runtime_error("invalid step value.");
+        }
+    }
+
+    values::value const& iterator::value() const
+    {
+        if (auto iterator = _value->as<values::iterator>()) {
+            return iterator->value();
+        }
+        return _value;
+    }
+
+    size_t iterator::step() const
+    {
+        return _step;
+    }
+
+    bool iterator::reverse() const
+    {
+        return _reverse;
+    }
+
+    void iterator::each(callback_type const& callback, bool reverse) const
+    {
+        if (!callback) {
+            return;
+        }
+
+        boost::apply_visitor(iteration_visitor{ callback, _step, reverse ? !_reverse : _reverse }, _value.get());
+    }
+
+    ostream& operator<<(ostream& os, values::iterator const& iterator)
+    {
+        bool is_hash = iterator.value().as<values::hash>();
+
+        if (is_hash) {
+            os << '{';
+        } else {
+            os << '[';
+        }
+
+        bool first = true;
+        iterator.each([&](auto const* key, auto const& value) {
+            if (first) {
+                first = false;
+            } else {
+                os << ", ";
+            }
+            if (key) {
+                os << *key << " => ";
+            }
+            os << value;
+            return true;
+        });
+
+        if (is_hash) {
+            os << '}';
+        } else {
+            os << ']';
+        }
+        return os;
+    }
+
+    bool operator==(iterator const& left, iterator const& right)
+    {
+        return left.step()    == right.step()    &&
+               left.reverse() == right.reverse() &&
+               left.value()   == right.value();
+    }
+
+    bool operator!=(iterator const& left, iterator const& right)
+    {
+        return !(left == right);
+    }
+
+    size_t hash_value(values::iterator const& iterator)
+    {
+        static const size_t name_hash = boost::hash_value("iterator");
+
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        boost::hash_combine(seed, iterator.value());
+        boost::hash_combine(seed, iterator.step());
+        boost::hash_combine(seed, iterator.reverse());
+        return seed;
+    }
+
+    iteration_visitor::iteration_visitor(iterator::callback_type const& callback, size_t step, bool reverse) :
+        _callback(callback),
+        _step(step),
+        _reverse(reverse)
+    {
+    }
+
+    void iteration_visitor::operator()(undef const&) const
+    {
+        throw runtime_error("undef is not iterable.");
+    }
+
+    void iteration_visitor::operator()(defaulted const&) const
+    {
+        throw runtime_error("defaulted is not iterable.");
+    }
+
+    void iteration_visitor::operator()(int64_t value) const
+    {
+        if (value <= 0) {
+            return;
+        }
+
+        for (int64_t i = (_reverse ? value - 1 : 0); i >= 0 && (_reverse ? true : i < value); i += (_reverse ? -_step : _step)) {
+            if (!_callback(nullptr, i)) {
+                break;
+            }
+            // Check for potential underflow/overflow
+            if ((_reverse && i < static_cast<int64_t>(_step)) || (!_reverse && i > (i + static_cast<int64_t>(_step)))) {
+                break;
+            }
+        }
+    }
+
+    void iteration_visitor::operator()(double) const
+    {
+        throw runtime_error("double is not iterable.");
+    }
+
+    void iteration_visitor::operator()(bool) const
+    {
+        throw runtime_error("boolean is not iterable.");
+    }
+
+    void iteration_visitor::operator()(std::string const& value) const
+    {
+        size_t step = 0;
+        each_code_point(
+            value,
+            [&](auto character) {
+                if (step > 0) {
+                    --step;
+                    return true;
+                }
+                step = _step - 1;
+                return _callback(nullptr, character);
+            },
+            _reverse
+        );
+    }
+
+    void iteration_visitor::operator()(values::regex const& value) const
+    {
+        throw runtime_error("regex is not iterable.");
+    }
+
+    void iteration_visitor::operator()(values::type const& value) const
+    {
+        if (auto integer = boost::get<types::integer>(&value)) {
+            operator()(*integer);
+            return;
+        }
+        if (auto enumeration = boost::get<types::enumeration>(&value)) {
+            operator()(*enumeration);
+            return;
+        }
+        throw runtime_error("type is not iterable.");
+    }
+
+    void iteration_visitor::operator()(types::integer const& range) const
+    {
+        if (!range.iterable()) {
+            return;
+        }
+
+        for (int64_t i = (_reverse ? range.to() : range.from()); i >= range.from() && (_reverse ? true : i <= range.to()); i += (_reverse ? -_step : _step)) {
+            if (!_callback(nullptr, i)) {
+                break;
+            }
+            // Check for potential underflow/overflow
+            if ((_reverse && i < (i - static_cast<int64_t>(_step))) || (!_reverse && i > (i + static_cast<int64_t>(_step)))) {
+                break;
+            }
+        }
+    }
+
+    void iteration_visitor::operator()(types::enumeration const& enumeration) const
+    {
+        for (auto& string : enumeration.strings()) {
+            if (!_callback(nullptr, string)) {
+                break;
+            }
+        }
+    }
+
+    void iteration_visitor::operator()(variable const& value) const
+    {
+        boost::apply_visitor(*this, value.value());
+    }
+
+    void iteration_visitor::operator()(values::array const& value) const
+    {
+        if (value.empty()) {
+            return;
+        }
+        for (size_t i = (_reverse ? value.size() - 1 : 0); _reverse ? true : i < value.size(); i += (_reverse ? -_step : _step)) {
+            if (!_callback(nullptr, value[i])) {
+                break;
+            }
+            // Check for potential underflow/overflow
+            if ((_reverse && i < _step) || (!_reverse && i > (i + _step))) {
+                break;
+            }
+        }
+    }
+
+    void iteration_visitor::operator()(values::hash const& value) const
+    {
+        if (value.empty()) {
+            return;
+        }
+        if (_reverse) {
+            size_t step = 0;
+            for (auto it = value.rbegin(); it != value.rend(); ++it) {
+                if (step > 0) {
+                    --step;
+                    continue;
+                }
+                step = _step - 1;
+                if (!_callback(&it->key(), it->value())) {
+                    return;
+                }
+            }
+            return;
+        }
+        size_t step = 0;
+        for (auto& kvp : value) {
+            if (step > 0) {
+                --step;
+                continue;
+            }
+            step = _step - 1;
+            if (!_callback(&kvp.key(), kvp.value())) {
+                return;
+            }
+        }
+    }
+
+    void iteration_visitor::operator()(values::iterator const& value) const
+    {
+        size_t step = 0;
+        value.each(
+            [&](auto const* key, auto const& value) {
+                if (step > 0) {
+                    --step;
+                    return true;
+                }
+                step = _step - 1;
+                return _callback(key, value);
+            },
+            _reverse
+        );
+    }
+
+}}}  // namespace puppet::runtime::values

--- a/lib/src/runtime/values/regex.cc
+++ b/lib/src/runtime/values/regex.cc
@@ -43,7 +43,12 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::regex const& regex)
     {
-        return boost::hash_value(regex.pattern());
+        static const size_t name_hash = boost::hash_value("regex");
+
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        boost::hash_combine(seed, regex.pattern());
+        return seed;
     }
 
 }}}  // namespace puppet::runtime::values

--- a/lib/src/runtime/values/type.cc
+++ b/lib/src/runtime/values/type.cc
@@ -97,6 +97,7 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::type const& type)
     {
+        // Hash the underlying type
         return hash_value(type.get());
     }
 

--- a/lib/src/runtime/values/undef.cc
+++ b/lib/src/runtime/values/undef.cc
@@ -21,7 +21,11 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::undef const&)
     {
-        return 0;
+        static const size_t name_hash = boost::hash_value("undef");
+
+        std::size_t seed = 0;
+        boost::hash_combine(seed, name_hash);
+        return seed;
     }
 
 }}}  // namespace puppet::runtime::values

--- a/lib/src/runtime/values/variable.cc
+++ b/lib/src/runtime/values/variable.cc
@@ -55,6 +55,7 @@ namespace puppet { namespace runtime { namespace values {
 
     size_t hash_value(values::variable const& variable)
     {
+        // Hash the underlying value
        return boost::hash_value(variable.value());
     }
 

--- a/lib/tests/fixtures/compiler/evaluation/each.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/each.baseline
@@ -1,0 +1,102 @@
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): [1, 2, 3]
+Notice: Scope(Class[main]): index = 0, value = 1
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 3
+Notice: Scope(Class[main]): [1, 2, 3]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): {foo => bar, bar => baz, baz => cake}
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): {foo => bar, bar => baz, baz => cake}
+Notice: Scope(Class[main]): value = 0
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 4
+Notice: Scope(Class[main]): 5
+Notice: Scope(Class[main]): index = 0, value = 0
+Notice: Scope(Class[main]): index = 1, value = 1
+Notice: Scope(Class[main]): index = 2, value = 2
+Notice: Scope(Class[main]): index = 3, value = 3
+Notice: Scope(Class[main]): index = 4, value = 4
+Notice: Scope(Class[main]): 5
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): Integer[5, 5]
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): value = 6
+Notice: Scope(Class[main]): value = 7
+Notice: Scope(Class[main]): value = 8
+Notice: Scope(Class[main]): value = 9
+Notice: Scope(Class[main]): value = 10
+Notice: Scope(Class[main]): Integer[5, 10]
+Notice: Scope(Class[main]): index = 0, value = 5
+Notice: Scope(Class[main]): index = 1, value = 6
+Notice: Scope(Class[main]): index = 2, value = 7
+Notice: Scope(Class[main]): index = 3, value = 8
+Notice: Scope(Class[main]): index = 4, value = 9
+Notice: Scope(Class[main]): index = 5, value = 10
+Notice: Scope(Class[main]): Integer[5, 10]
+Notice: Scope(Class[main]): value = foo
+Notice: Scope(Class[main]): value = bar
+Notice: Scope(Class[main]): value = baz
+Notice: Scope(Class[main]): Enum[foo, bar, baz]
+Notice: Scope(Class[main]): index = 0, value = foo
+Notice: Scope(Class[main]): index = 1, value = bar
+Notice: Scope(Class[main]): index = 2, value = baz
+Notice: Scope(Class[main]): Enum[foo, bar, baz]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/each.pp
+++ b/lib/tests/fixtures/compiler/evaluation/each.pp
@@ -1,0 +1,53 @@
+[].each |$value| {
+    fail incorrect
+}
+
+notice [1, 2, 3].each |$value| {
+    notice "value = $value"
+}
+
+notice [1, 2, 3].each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+{}.each |$value| {
+    fail incorrect
+}
+
+notice { foo => bar, bar => baz, baz => cake }.each |$value| {
+    notice "value = $value"
+}
+
+notice { foo => bar, bar => baz, baz => cake }.each |$key, $value| {
+    notice "key = $key, value = $value"
+}
+
+notice 5.each |$value| {
+    notice "value = $value"
+}
+
+notice 5.each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice Integer[5, 5].each |$value| {
+    notice "value = $value"
+}
+
+notice Integer[5, 10].each |$value| {
+    notice "value = $value"
+}
+
+notice Integer[5, 10].each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice Enum[foo, bar, baz].each |$value| {
+    notice "value = $value"
+}
+
+notice Enum[foo, bar, baz].each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+# TODO: add tests for iterators when they can be instantiated

--- a/lib/tests/fixtures/compiler/evaluation/filter.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/filter.baseline
@@ -1,0 +1,102 @@
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): [1, 2]
+Notice: Scope(Class[main]): index = 0, value = 1
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 3
+Notice: Scope(Class[main]): [1, 2]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): {bar => baz}
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): {bar => baz}
+Notice: Scope(Class[main]): value = 0
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 4
+Notice: Scope(Class[main]): [0, 1]
+Notice: Scope(Class[main]): index = 0, value = 0
+Notice: Scope(Class[main]): index = 1, value = 1
+Notice: Scope(Class[main]): index = 2, value = 2
+Notice: Scope(Class[main]): index = 3, value = 3
+Notice: Scope(Class[main]): index = 4, value = 4
+Notice: Scope(Class[main]): [0, 1]
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): []
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): value = 6
+Notice: Scope(Class[main]): value = 7
+Notice: Scope(Class[main]): value = 8
+Notice: Scope(Class[main]): value = 9
+Notice: Scope(Class[main]): value = 10
+Notice: Scope(Class[main]): [5, 6]
+Notice: Scope(Class[main]): index = 0, value = 5
+Notice: Scope(Class[main]): index = 1, value = 6
+Notice: Scope(Class[main]): index = 2, value = 7
+Notice: Scope(Class[main]): index = 3, value = 8
+Notice: Scope(Class[main]): index = 4, value = 9
+Notice: Scope(Class[main]): index = 5, value = 10
+Notice: Scope(Class[main]): [5, 6]
+Notice: Scope(Class[main]): value = foo
+Notice: Scope(Class[main]): value = bar
+Notice: Scope(Class[main]): value = baz
+Notice: Scope(Class[main]): [bar, baz]
+Notice: Scope(Class[main]): index = 0, value = foo
+Notice: Scope(Class[main]): index = 1, value = bar
+Notice: Scope(Class[main]): index = 2, value = baz
+Notice: Scope(Class[main]): [bar, baz]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/filter.pp
+++ b/lib/tests/fixtures/compiler/evaluation/filter.pp
@@ -1,0 +1,64 @@
+[].filter |$value| {
+    fail incorrect
+}
+
+notice [1, 2, 3].filter |$value| {
+    notice "value = $value"
+    $value < 3
+}
+
+notice [1, 2, 3].filter |$index, $value| {
+    notice "index = $index, value = $value"
+    $value < 3
+}
+
+{}.filter |$value| {
+    fail incorrect
+}
+
+notice { foo => bar, bar => baz, baz => cake }.filter |$value| {
+    notice "value = $value"
+    $value[0] == bar
+}
+
+notice { foo => bar, bar => baz, baz => cake }.filter |$key, $value| {
+    notice "key = $key, value = $value"
+    $key == bar
+}
+
+notice 5.filter |$value| {
+    notice "value = $value"
+    $value < 2
+}
+
+notice 5.filter |$index, $value| {
+    notice "index = $index, value = $value"
+    $value < 2
+}
+
+notice Integer[5, 5].filter |$value| {
+    notice "value = $value"
+    $value != 5
+}
+
+notice Integer[5, 10].filter |$value| {
+    notice "value = $value"
+    $value < 7
+}
+
+notice Integer[5, 10].filter |$index, $value| {
+    notice "index = $index, value = $value"
+    $value < 7
+}
+
+notice Enum[foo, bar, baz].filter |$value| {
+    notice "value = $value"
+    $value =~ /^b/
+}
+
+notice Enum[foo, bar, baz].filter |$index, $value| {
+    notice "index = $index, value = $value"
+    $value =~ /^b/
+}
+
+# TODO: add tests for iterators when they can be instantiated

--- a/lib/tests/fixtures/compiler/evaluation/iterable.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/iterable.baseline
@@ -1,0 +1,52 @@
+Notice: Scope(Class[main]): Iterable
+Notice: Scope(Class[main]): Iterable[String]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/iterable.pp
+++ b/lib/tests/fixtures/compiler/evaluation/iterable.pp
@@ -1,0 +1,90 @@
+# Iterable tests
+
+notice Iterable
+notice Iterable[String]
+
+if undef =~ Iterable {
+    fail incorrect
+}
+
+unless [1, 2, 3] =~ Iterable {
+    fail incorrect
+}
+
+unless [1, 2, 3] =~ Iterable[Integer] {
+    fail incorrect
+}
+
+if [1, 2, 3] =~ Iterable[String] {
+    fail incorrect
+}
+
+unless { foo => 1, bar => 2, baz => 3 } =~ Iterable {
+    fail incorrect
+}
+
+unless { foo => 1, bar => 2, baz => 3 } =~ Iterable[Tuple[String, Integer]] {
+    fail incorrect
+}
+
+if { foo => 1, bar => 2, baz => 3 } =~ Iterable[Tuple[Integer, Integer]] {
+    fail incorrect
+}
+
+unless 5 =~ Iterable {
+    fail incorrect
+}
+
+unless 1 =~ Iterable {
+    fail incorrect
+}
+
+unless 0 =~ Iterable {
+    fail incorrect
+}
+
+if -5 =~ Iterable {
+    fail incorrect
+}
+
+unless 5 =~ Iterable[Integer[0, 4]] {
+    fail incorrect
+}
+
+if 5 =~ Iterable[Integer[1, 4]] {
+    fail incorrect
+}
+
+if 5 =~ Iterable[Integer[0, 5]] {
+    fail incorrect
+}
+
+unless Integer[10, 100] =~ Iterable {
+    fail incorrect
+}
+
+unless Integer[-10, 10] =~ Iterable {
+    fail incorrect
+}
+
+if Integer[default, 10] =~ Iterable {
+    fail incorrect
+}
+
+if Integer[10, default] =~ Iterable {
+    fail incorrect
+}
+
+unless Integer[0, 10] =~ Iterable[Integer[0, 10]] {
+    fail incorrect
+}
+
+unless Enum[foo, bar] =~ Iterable {
+    fail incorrect
+}
+
+unless Enum[foo, bar] =~ Iterable[Enum[foo, bar]] {
+    fail incorrect
+}
+
+# TODO: add check for iterators in the future

--- a/lib/tests/fixtures/compiler/evaluation/iterator.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/iterator.baseline
@@ -1,0 +1,52 @@
+Notice: Scope(Class[main]): Iterator
+Notice: Scope(Class[main]): Iterator[String]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/iterator.pp
+++ b/lib/tests/fixtures/compiler/evaluation/iterator.pp
@@ -1,0 +1,6 @@
+# Iterator tests
+
+notice Iterator
+notice Iterator[String]
+
+# TODO: add more tests when iterator values can be instantiated

--- a/lib/tests/fixtures/compiler/evaluation/map.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/map.baseline
@@ -1,0 +1,102 @@
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): [2, 3, 4]
+Notice: Scope(Class[main]): index = 0, value = 1
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 3
+Notice: Scope(Class[main]): [2, 3, 4]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): [foo, bar, baz]
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): [foo, bar, baz]
+Notice: Scope(Class[main]): value = 0
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 4
+Notice: Scope(Class[main]): [1, 2, 3, 4, 5]
+Notice: Scope(Class[main]): index = 0, value = 0
+Notice: Scope(Class[main]): index = 1, value = 1
+Notice: Scope(Class[main]): index = 2, value = 2
+Notice: Scope(Class[main]): index = 3, value = 3
+Notice: Scope(Class[main]): index = 4, value = 4
+Notice: Scope(Class[main]): [1, 2, 3, 4, 5]
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): [6]
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): value = 6
+Notice: Scope(Class[main]): value = 7
+Notice: Scope(Class[main]): value = 8
+Notice: Scope(Class[main]): value = 9
+Notice: Scope(Class[main]): value = 10
+Notice: Scope(Class[main]): [6, 7, 8, 9, 10, 11]
+Notice: Scope(Class[main]): index = 0, value = 5
+Notice: Scope(Class[main]): index = 1, value = 6
+Notice: Scope(Class[main]): index = 2, value = 7
+Notice: Scope(Class[main]): index = 3, value = 8
+Notice: Scope(Class[main]): index = 4, value = 9
+Notice: Scope(Class[main]): index = 5, value = 10
+Notice: Scope(Class[main]): [6, 7, 8, 9, 10, 11]
+Notice: Scope(Class[main]): value = foo
+Notice: Scope(Class[main]): value = bar
+Notice: Scope(Class[main]): value = baz
+Notice: Scope(Class[main]): [value = foo, value = bar, value = baz]
+Notice: Scope(Class[main]): index = 0, value = foo
+Notice: Scope(Class[main]): index = 1, value = bar
+Notice: Scope(Class[main]): index = 2, value = baz
+Notice: Scope(Class[main]): [value = foo, value = bar, value = baz]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/map.pp
+++ b/lib/tests/fixtures/compiler/evaluation/map.pp
@@ -1,0 +1,64 @@
+[].map |$value| {
+    fail incorrect
+}
+
+notice [1, 2, 3].map |$value| {
+    notice "value = $value"
+    $value + 1
+}
+
+notice [1, 2, 3].map |$index, $value| {
+    notice "index = $index, value = $value"
+    $value + 1
+}
+
+{}.map |$value| {
+    fail incorrect
+}
+
+notice { foo => bar, bar => baz, baz => cake }.map |$value| {
+    notice "value = $value"
+    $value[0]
+}
+
+notice { foo => bar, bar => baz, baz => cake }.map |$key, $value| {
+    notice "key = $key, value = $value"
+    $key
+}
+
+notice 5.map |$value| {
+    notice "value = $value"
+    $value + 1
+}
+
+notice 5.map |$index, $value| {
+    notice "index = $index, value = $value"
+    $value + 1
+}
+
+notice Integer[5, 5].map |$value| {
+    notice "value = $value"
+    $value + 1
+}
+
+notice Integer[5, 10].map |$value| {
+    notice "value = $value"
+    $value + 1
+}
+
+notice Integer[5, 10].map |$index, $value| {
+    notice "index = $index, value = $value"
+    $value + 1
+}
+
+notice Enum[foo, bar, baz].map |$value| {
+    notice "value = $value"
+    "value = $value"
+}
+
+notice Enum[foo, bar, baz].map |$index, $value| {
+    notice "index = $index, value = $value"
+    "value = $value"
+}
+
+# TODO: add tests for iterators when they can be instantiated

--- a/lib/tests/fixtures/compiler/evaluation/reduce.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/reduce.baseline
@@ -1,0 +1,88 @@
+Notice: Scope(Class[main]): memo = 1, value = 2
+Notice: Scope(Class[main]): memo = 3, value = 3
+Notice: Scope(Class[main]): 6
+Notice: Scope(Class[main]): memo = 1, value = 2
+Notice: Scope(Class[main]): memo = 3, value = 3
+Notice: Scope(Class[main]): 6
+Notice: Scope(Class[main]): memo = [foo, bar], value = [bar, baz]
+Notice: Scope(Class[main]): memo = [foo, bar, bar, baz], value = [baz, cake]
+Notice: Scope(Class[main]): [foo, bar, bar, baz, baz, cake]
+Notice: Scope(Class[main]): memo = [foo, bar], value = [bar, baz]
+Notice: Scope(Class[main]): memo = [foo, bar, bar, baz], value = [baz, cake]
+Notice: Scope(Class[main]): [foo, bar, bar, baz, baz, cake]
+Notice: Scope(Class[main]): memo = 0, value = 1
+Notice: Scope(Class[main]): memo = 1, value = 2
+Notice: Scope(Class[main]): memo = 3, value = 3
+Notice: Scope(Class[main]): memo = 6, value = 4
+Notice: Scope(Class[main]): 10
+Notice: Scope(Class[main]): 5
+Notice: Scope(Class[main]): memo = 1, value = 5
+Notice: Scope(Class[main]): 6
+Notice: Scope(Class[main]): memo = 5, value = 6
+Notice: Scope(Class[main]): memo = 11, value = 7
+Notice: Scope(Class[main]): memo = 18, value = 8
+Notice: Scope(Class[main]): memo = 26, value = 9
+Notice: Scope(Class[main]): memo = 35, value = 10
+Notice: Scope(Class[main]): 45
+Notice: Scope(Class[main]): memo = 5, value = 6
+Notice: Scope(Class[main]): memo = 11, value = 7
+Notice: Scope(Class[main]): memo = 18, value = 8
+Notice: Scope(Class[main]): memo = 26, value = 9
+Notice: Scope(Class[main]): memo = 35, value = 10
+Notice: Scope(Class[main]): 45
+Notice: Scope(Class[main]): memo = foo, value = bar
+Notice: Scope(Class[main]): memo = foobar, value = baz
+Notice: Scope(Class[main]): foobarbaz
+Notice: Scope(Class[main]): memo = foo, value = bar
+Notice: Scope(Class[main]): memo = foobar, value = baz
+Notice: Scope(Class[main]): foobarbaz
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/reduce.pp
+++ b/lib/tests/fixtures/compiler/evaluation/reduce.pp
@@ -1,0 +1,67 @@
+if [].reduce |$memo, $value| {
+    fail incorrect
+} {
+    fail incorrect
+}
+
+notice [1, 2, 3].reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice [2, 3].reduce(1) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+if {}.reduce |$memo, $value| {
+    fail incorrect
+} {
+    fail incorrect
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo << $value[0] << $value[1]
+}
+
+notice { bar => baz, baz => cake }.reduce([foo, bar]) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo << $value[0] << $value[1]
+}
+
+notice 5.reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice Integer[5, 5].reduce |$memo, $value| {
+    fail incorrect
+}
+
+notice Integer[5, 5].reduce(1) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice Integer[5, 10].reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice Integer[6, 10].reduce(5) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice Enum[foo, bar, baz].reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    "$memo$value"
+}
+
+notice Enum[bar, baz].reduce(foo) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    "$memo$value"
+}
+
+# TODO: add tests for iterators when they can be instantiated


### PR DESCRIPTION
NOTE: this is dependent upon #126.

This implements the `Iterator` type and value.

Currently an iterator value cannot be created because functions that return iterators (such as `reverse_each` and `step`) are not yet implemented.

This also adds test coverage for functions that iterate (`each`, `filter`, `map`, and `reduce`).