### PR TITLE
(NPUP-35) Implement the `reverse_each` function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ Puppet functions implemented:
 * [x] reduce
 * [ ] regsubst
 * [x] require
-* [ ] reverse_each
+* [x] reverse_each
 * [ ] scanf
 * [ ] sha1
 * [ ] shellquote

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -39,6 +39,7 @@ set(PUPPET_COMMON_SOURCES
     src/compiler/evaluation/functions/realize.cc
     src/compiler/evaluation/functions/reduce.cc
     src/compiler/evaluation/functions/require.cc
+    src/compiler/evaluation/functions/reverse_each.cc
     src/compiler/evaluation/functions/split.cc
     src/compiler/evaluation/functions/tag.cc
     src/compiler/evaluation/functions/tagged.cc

--- a/lib/include/puppet/compiler/evaluation/functions/reverse_each.hpp
+++ b/lib/include/puppet/compiler/evaluation/functions/reverse_each.hpp
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Declares the reverse_each function.
+ */
+#pragma once
+
+#include "descriptor.hpp"
+
+namespace puppet { namespace compiler { namespace evaluation { namespace functions {
+
+    /**
+     * Implements the reverse_each function.
+     */
+    struct reverse_each
+    {
+        /**
+         * Create a function descriptor.
+         * @return Returns the function descriptor representing this function.
+         */
+        static descriptor create_descriptor();
+    };
+
+}}}}  // puppet::compiler::evaluation::functions

--- a/lib/src/compiler/evaluation/dispatcher.cc
+++ b/lib/src/compiler/evaluation/dispatcher.cc
@@ -19,6 +19,7 @@
 #include <puppet/compiler/evaluation/functions/realize.hpp>
 #include <puppet/compiler/evaluation/functions/reduce.hpp>
 #include <puppet/compiler/evaluation/functions/require.hpp>
+#include <puppet/compiler/evaluation/functions/reverse_each.hpp>
 #include <puppet/compiler/evaluation/functions/split.hpp>
 #include <puppet/compiler/evaluation/functions/tag.hpp>
 #include <puppet/compiler/evaluation/functions/tagged.hpp>
@@ -84,6 +85,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         add(functions::realize::create_descriptor());
         add(functions::reduce::create_descriptor());
         add(functions::require::create_descriptor());
+        add(functions::reverse_each::create_descriptor());
         add(functions::split::create_descriptor());
         add(functions::tag::create_descriptor());
         add(functions::tagged::create_descriptor());

--- a/lib/src/compiler/evaluation/functions/reverse_each.cc
+++ b/lib/src/compiler/evaluation/functions/reverse_each.cc
@@ -1,0 +1,51 @@
+#include <puppet/compiler/evaluation/functions/reverse_each.hpp>
+#include <puppet/compiler/evaluation/functions/call_context.hpp>
+#include <puppet/cast.hpp>
+
+using namespace std;
+using namespace puppet::runtime;
+
+namespace puppet { namespace compiler { namespace evaluation { namespace functions {
+
+    descriptor reverse_each::create_descriptor()
+    {
+        functions::descriptor descriptor{ "reverse_each" };
+
+        descriptor.add("Callable[Iterable, 1, 1]", [](call_context& context) {
+            return values::iterator{ rvalue_cast(context.argument(0)), 1, true };
+        });
+
+        descriptor.add("Callable[Iterable, 1, 1, Callable[1, 2]]", [](call_context& context) {
+            values::array block_arguments(context.block()->parameters.size());
+            int64_t index = 0;
+
+            values::iterator iterator{ rvalue_cast(context.argument(0)), 1, true };
+
+            iterator.each([&](auto const* key, auto const& value) {
+                if (key) {
+                    if (block_arguments.size() == 1) {
+                        values::array pair(2);
+                        pair[0] = *key;
+                        pair[1] = value;
+                        block_arguments[0] = rvalue_cast(pair);
+                    } else {
+                        block_arguments[0] = *key;
+                        block_arguments[1] = value;
+                    }
+                } else {
+                    if (block_arguments.size() == 1) {
+                        block_arguments[0] = value;
+                    } else {
+                        block_arguments[0] = index++;
+                        block_arguments[1] = value;
+                    }
+                }
+                context.yield(block_arguments);
+                return true;
+            });
+            return iterator;
+        });
+        return descriptor;
+    }
+
+}}}}  // namespace puppet::compiler::evaluation::functions

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -133,6 +133,16 @@ namespace puppet { namespace runtime { namespace types {
 
     bool iterable::is_assignable(values::type const& other, recursion_guard& guard) const
     {
+        // Check for Iterable
+        if (auto iterable = boost::get<types::iterable>(&other)) {
+            if (!_type) {
+                return true;
+            }
+            if (!iterable->type()) {
+                return false;
+            }
+            return _type->is_assignable(*iterable->type(), guard);
+        }
         // Check for string
         if (boost::get<types::string>(&other)) {
             return !_type || _type->is_assignable(other, guard);

--- a/lib/tests/fixtures/compiler/evaluation/each.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/each.baseline
@@ -50,6 +50,22 @@ Notice: Scope(Class[main]): index = 0, value = foo
 Notice: Scope(Class[main]): index = 1, value = bar
 Notice: Scope(Class[main]): index = 2, value = baz
 Notice: Scope(Class[main]): Enum[foo, bar, baz]
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): [3, 2, 1]
+Notice: Scope(Class[main]): index = 0, value = 3
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 1
+Notice: Scope(Class[main]): [3, 2, 1]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): {baz => cake, bar => baz, foo => bar}
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): {baz => cake, bar => baz, foo => bar}
 {
   "name": "test",
   "version": 123456789

--- a/lib/tests/fixtures/compiler/evaluation/each.pp
+++ b/lib/tests/fixtures/compiler/evaluation/each.pp
@@ -50,4 +50,18 @@ notice Enum[foo, bar, baz].each |$index, $value| {
     notice "index = $index, value = $value"
 }
 
-# TODO: add tests for iterators when they can be instantiated
+notice [1, 2, 3].reverse_each.each |$value| {
+    notice "value = $value"
+}
+
+notice [1, 2, 3].reverse_each.each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.each |$value| {
+    notice "value = $value"
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.each |$key, $value| {
+    notice "key = $key, value = $value"
+}

--- a/lib/tests/fixtures/compiler/evaluation/filter.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/filter.baseline
@@ -50,6 +50,22 @@ Notice: Scope(Class[main]): index = 0, value = foo
 Notice: Scope(Class[main]): index = 1, value = bar
 Notice: Scope(Class[main]): index = 2, value = baz
 Notice: Scope(Class[main]): [bar, baz]
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): [3, 2]
+Notice: Scope(Class[main]): index = 0, value = 3
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 1
+Notice: Scope(Class[main]): [3, 2]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): {baz => cake, bar => baz}
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): {baz => cake, bar => baz}
 {
   "name": "test",
   "version": 123456789

--- a/lib/tests/fixtures/compiler/evaluation/filter.pp
+++ b/lib/tests/fixtures/compiler/evaluation/filter.pp
@@ -61,4 +61,22 @@ notice Enum[foo, bar, baz].filter |$index, $value| {
     $value =~ /^b/
 }
 
-# TODO: add tests for iterators when they can be instantiated
+notice [1, 2, 3].reverse_each.filter |$value| {
+    notice "value = $value"
+    $value > 1
+}
+
+notice [1, 2, 3].reverse_each.filter |$index, $value| {
+    notice "index = $index, value = $value"
+    $value > 1
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.filter |$value| {
+    notice "value = $value"
+    $value[0] =~ /^b/
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.filter |$key, $value| {
+    notice "key = $key, value = $value"
+    $key =~ /^b/
+}

--- a/lib/tests/fixtures/compiler/evaluation/iterable.pp
+++ b/lib/tests/fixtures/compiler/evaluation/iterable.pp
@@ -87,4 +87,10 @@ unless Enum[foo, bar] =~ Iterable[Enum[foo, bar]] {
     fail incorrect
 }
 
-# TODO: add check for iterators in the future
+unless [1, 2, 3].reverse_each =~ Iterable {
+    fail incorrect
+}
+
+unless [1, foo, 3].reverse_each =~ Iterable[Variant[String, Integer]] {
+    fail incorrect
+}

--- a/lib/tests/fixtures/compiler/evaluation/iterator.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/iterator.baseline
@@ -1,5 +1,7 @@
 Notice: Scope(Class[main]): Iterator
 Notice: Scope(Class[main]): Iterator[String]
+Notice: Scope(Class[main]): [3, 2, 1]
+Notice: Scope(Class[main]): {baz => cake, bar => baz, foo => bar}
 {
   "name": "test",
   "version": 123456789

--- a/lib/tests/fixtures/compiler/evaluation/iterator.pp
+++ b/lib/tests/fixtures/compiler/evaluation/iterator.pp
@@ -3,4 +3,29 @@
 notice Iterator
 notice Iterator[String]
 
-# TODO: add more tests when iterator values can be instantiated
+notice [1, 2, 3].reverse_each
+notice { foo => bar, bar => baz, baz => cake }.reverse_each
+
+if undef =~ Iterator {
+    fail incorrect
+}
+
+unless [1, 2, 3].reverse_each =~ Iterator {
+    fail incorrect
+}
+
+unless [1, 2, 3].reverse_each =~ Iterator[Integer] {
+    fail incorrect
+}
+
+if [1, 2, 3].reverse_each =~ Iterator[String] {
+    fail incorrect
+}
+
+unless [1, 2, 3].reverse_each == [1, 2, 3].reverse_each {
+    fail incorrect
+}
+
+if [1, 2, 3].reverse_each != [1, 2, 3].reverse_each {
+    fail incorrect
+}

--- a/lib/tests/fixtures/compiler/evaluation/map.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/map.baseline
@@ -50,6 +50,22 @@ Notice: Scope(Class[main]): index = 0, value = foo
 Notice: Scope(Class[main]): index = 1, value = bar
 Notice: Scope(Class[main]): index = 2, value = baz
 Notice: Scope(Class[main]): [value = foo, value = bar, value = baz]
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): [2, 1, 0]
+Notice: Scope(Class[main]): index = 0, value = 3
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 1
+Notice: Scope(Class[main]): [2, 1, 0]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): [baz, bar, foo]
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): [baz, bar, foo]
 {
   "name": "test",
   "version": 123456789

--- a/lib/tests/fixtures/compiler/evaluation/map.pp
+++ b/lib/tests/fixtures/compiler/evaluation/map.pp
@@ -61,4 +61,22 @@ notice Enum[foo, bar, baz].map |$index, $value| {
     "value = $value"
 }
 
-# TODO: add tests for iterators when they can be instantiated
+notice [1, 2, 3].reverse_each.map |$value| {
+    notice "value = $value"
+    $value - 1
+}
+
+notice [1, 2, 3].reverse_each.map |$index, $value| {
+    notice "index = $index, value = $value"
+    $value - 1
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.map |$value| {
+    notice "value = $value"
+    $value[0]
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.map |$key, $value| {
+    notice "key = $key, value = $value"
+    $key
+}

--- a/lib/tests/fixtures/compiler/evaluation/reduce.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/reduce.baseline
@@ -36,6 +36,18 @@ Notice: Scope(Class[main]): foobarbaz
 Notice: Scope(Class[main]): memo = foo, value = bar
 Notice: Scope(Class[main]): memo = foobar, value = baz
 Notice: Scope(Class[main]): foobarbaz
+Notice: Scope(Class[main]): memo = 3, value = 2
+Notice: Scope(Class[main]): memo = 5, value = 1
+Notice: Scope(Class[main]): 6
+Notice: Scope(Class[main]): memo = 3, value = 2
+Notice: Scope(Class[main]): memo = 5, value = 1
+Notice: Scope(Class[main]): 6
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): [baz, cake, bar, baz, foo, bar]
+Notice: Scope(Class[main]): key = , value = [bar, baz]
+Notice: Scope(Class[main]): key = , value = [foo, bar]
+Notice: Scope(Class[main]): [baz, cake, bar, baz, foo, bar]
 {
   "name": "test",
   "version": 123456789

--- a/lib/tests/fixtures/compiler/evaluation/reduce.pp
+++ b/lib/tests/fixtures/compiler/evaluation/reduce.pp
@@ -64,4 +64,22 @@ notice Enum[bar, baz].reduce(foo) |$memo, $value| {
     "$memo$value"
 }
 
-# TODO: add tests for iterators when they can be instantiated
+notice [1, 2, 3].reverse_each.reduce |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice [1, 2].reverse_each.reduce(3) |$memo, $value| {
+    notice "memo = $memo, value = $value"
+    $memo + $value
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.reduce |$memo, $value| {
+    notice "value = $value"
+    $memo << $value[0] << $value[1]
+}
+
+notice { foo => bar, bar => baz }.reverse_each.reduce([baz, cake]) |$memo, $value| {
+    notice "key = $key, value = $value"
+    $memo + $value
+}

--- a/lib/tests/fixtures/compiler/evaluation/reverse_each.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/reverse_each.baseline
@@ -1,0 +1,110 @@
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): [3, 2, 1]
+Notice: Scope(Class[main]): index = 0, value = 3
+Notice: Scope(Class[main]): index = 1, value = 2
+Notice: Scope(Class[main]): index = 2, value = 1
+Notice: Scope(Class[main]): [3, 2, 1]
+Notice: Scope(Class[main]): value = [baz, cake]
+Notice: Scope(Class[main]): value = [bar, baz]
+Notice: Scope(Class[main]): value = [foo, bar]
+Notice: Scope(Class[main]): {baz => cake, bar => baz, foo => bar}
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): {baz => cake, bar => baz, foo => bar}
+Notice: Scope(Class[main]): value = 4
+Notice: Scope(Class[main]): value = 3
+Notice: Scope(Class[main]): value = 2
+Notice: Scope(Class[main]): value = 1
+Notice: Scope(Class[main]): value = 0
+Notice: Scope(Class[main]): [4, 3, 2, 1, 0]
+Notice: Scope(Class[main]): index = 0, value = 4
+Notice: Scope(Class[main]): index = 1, value = 3
+Notice: Scope(Class[main]): index = 2, value = 2
+Notice: Scope(Class[main]): index = 3, value = 1
+Notice: Scope(Class[main]): index = 4, value = 0
+Notice: Scope(Class[main]): [4, 3, 2, 1, 0]
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): [5]
+Notice: Scope(Class[main]): value = 10
+Notice: Scope(Class[main]): value = 9
+Notice: Scope(Class[main]): value = 8
+Notice: Scope(Class[main]): value = 7
+Notice: Scope(Class[main]): value = 6
+Notice: Scope(Class[main]): value = 5
+Notice: Scope(Class[main]): [10, 9, 8, 7, 6, 5]
+Notice: Scope(Class[main]): index = 0, value = 10
+Notice: Scope(Class[main]): index = 1, value = 9
+Notice: Scope(Class[main]): index = 2, value = 8
+Notice: Scope(Class[main]): index = 3, value = 7
+Notice: Scope(Class[main]): index = 4, value = 6
+Notice: Scope(Class[main]): index = 5, value = 5
+Notice: Scope(Class[main]): [10, 9, 8, 7, 6, 5]
+Notice: Scope(Class[main]): value = foo
+Notice: Scope(Class[main]): value = bar
+Notice: Scope(Class[main]): value = baz
+Notice: Scope(Class[main]): [foo, bar, baz]
+Notice: Scope(Class[main]): index = 0, value = foo
+Notice: Scope(Class[main]): index = 1, value = bar
+Notice: Scope(Class[main]): index = 2, value = baz
+Notice: Scope(Class[main]): [foo, bar, baz]
+Notice: Scope(Class[main]): 1
+Notice: Scope(Class[main]): 2
+Notice: Scope(Class[main]): 3
+Notice: Scope(Class[main]): [1, 2, 3]
+Notice: Scope(Class[main]): key = foo, value = bar
+Notice: Scope(Class[main]): key = bar, value = baz
+Notice: Scope(Class[main]): key = baz, value = cake
+Notice: Scope(Class[main]): {foo => bar, bar => baz, baz => cake}
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/reverse_each.pp
+++ b/lib/tests/fixtures/compiler/evaluation/reverse_each.pp
@@ -1,0 +1,59 @@
+[].reverse_each |$value| {
+    fail incorrect
+}
+
+notice [1, 2, 3].reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice [1, 2, 3].reverse_each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+{}.reverse_each |$value| {
+    fail incorrect
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each |$key, $value| {
+    notice "key = $key, value = $value"
+}
+
+notice 5.reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice 5.reverse_each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice Integer[5, 5].reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice Integer[5, 10].reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice Integer[5, 10].reverse_each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice Enum[foo, bar, baz].reverse_each |$value| {
+    notice "value = $value"
+}
+
+notice Enum[foo, bar, baz].reverse_each |$index, $value| {
+    notice "index = $index, value = $value"
+}
+
+notice [1, 2, 3].reverse_each.reverse_each |$value| {
+    notice $value
+}
+
+notice { foo => bar, bar => baz, baz => cake }.reverse_each.reverse_each |$key, $value| {
+    notice "key = $key, value = $value"
+}

--- a/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
+++ b/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
@@ -1193,7 +1193,221 @@ if Iterable[Integer] > Enum[foo] {
     fail incorrect
 }
 
-# TODO: add tests for Iterable compared to Iterator
+unless Iterable > Iterator {
+    fail incorrect
+}
+
+unless Iterable[Numeric] > Iterator[Integer] {
+    fail incorrect
+}
+
+if Iterable[Integer] > Iterator[String] {
+    fail incorrect
+}
+
+unless Iterable >= Iterable and Iterable[String] >= Iterable[String] {
+    fail incorrect
+}
+
+if Iterable >= Float {
+    fail incorrect
+}
+
+unless Iterable >= String and Iterable[String] >= String {
+    fail incorrect
+}
+
+unless Iterable >= Array {
+    fail incorrect
+}
+
+if Iterable[Integer] >= Array or Iterable[Integer] >= Array[String] {
+    fail incorrect
+}
+
+unless Iterable[String] >= Array[String] {
+    fail incorrect
+}
+
+unless Iterable >= Hash and Iterable[Tuple[String, Integer]] >= Hash[String, Integer] {
+    fail incorrect
+}
+
+if Iterable[String] >= Hash or Iterable[Tuple[String]] >= Hash[String, String] or Iterable[Tuple[String, Integer]] >= Hash[Integer, String] {
+    fail incorrect
+}
+
+if Iterable >= Integer or Iterable >= Integer[0, default] or Iterable >= Integer[default, 10] {
+    fail incorrect
+}
+
+unless Iterable >= Integer[0, 10] and Iterable[Integer] >= Integer[0, 10] {
+    fail incorrect
+}
+
+if Iterable[String] >= Integer[0, 10] or Iterable[Integer[0, 10]] >= Integer[20, 30] {
+    fail incorrect
+}
+
+unless Iterable >= Enum {
+    fail incorrect
+}
+
+unless Iterable[String] >= Enum[foo] {
+    fail incorrect
+}
+
+if Iterable[Integer] >= Enum[foo] {
+    fail incorrect
+}
+
+unless Iterable >= Iterator {
+    fail incorrect
+}
+
+unless Iterable[Numeric] >= Iterator[Integer] {
+    fail incorrect
+}
+
+if Iterable[Integer] >= Iterator[String] {
+    fail incorrect
+}
+
+if Iterable < Iterable or Iterable[String] < Iterable[String] {
+    fail incorrect
+}
+
+if Iterable < Float {
+    fail incorrect
+}
+
+if Iterable < String or Iterable[String] < String {
+    fail incorrect
+}
+
+if Iterable < Array {
+    fail incorrect
+}
+
+if Iterable[Integer] < Array or Iterable[Integer] < Array[String] {
+    fail incorrect
+}
+
+if Iterable[String] < Array[String] {
+    fail incorrect
+}
+
+if Iterable < Hash or Iterable[Tuple[String, Integer]] < Hash[String, Integer] {
+    fail incorrect
+}
+
+if Iterable[String] < Hash or Iterable[Tuple[String]] < Hash[String, String] or Iterable[Tuple[String, Integer]] < Hash[Integer, String] {
+    fail incorrect
+}
+
+if Iterable < Integer or Iterable < Integer[0, default] or Iterable < Integer[default, 10] {
+    fail incorrect
+}
+
+if Iterable < Integer[0, 10] or Iterable[Integer] < Integer[0, 10] {
+    fail incorrect
+}
+
+if Iterable[String] < Integer[0, 10] or Iterable[Integer[0, 10]] < Integer[20, 30] {
+    fail incorrect
+}
+
+if Iterable < Enum {
+    fail incorrect
+}
+
+if Iterable[String] < Enum[foo] {
+    fail incorrect
+}
+
+if Iterable[Integer] < Enum[foo] {
+    fail incorrect
+}
+
+if Iterable < Iterator {
+    fail incorrect
+}
+
+if Iterable[Numeric] < Iterator[Integer] {
+    fail incorrect
+}
+
+if Iterable[Integer] < Iterator[String] {
+    fail incorrect
+}
+
+unless Iterable <= Iterable and Iterable[String] <= Iterable[String] {
+    fail incorrect
+}
+
+if Iterable <= Float {
+    fail incorrect
+}
+
+if Iterable <= String or Iterable[String] <= String {
+    fail incorrect
+}
+
+if Iterable <= Array {
+    fail incorrect
+}
+
+if Iterable[Integer] <= Array or Iterable[Integer] <= Array[String] {
+    fail incorrect
+}
+
+if Iterable[String] <= Array[String] {
+    fail incorrect
+}
+
+if Iterable <= Hash or Iterable[Tuple[String, Integer]] <= Hash[String, Integer] {
+    fail incorrect
+}
+
+if Iterable[String] <= Hash or Iterable[Tuple[String]] <= Hash[String, String] or Iterable[Tuple[String, Integer]] <= Hash[Integer, String] {
+    fail incorrect
+}
+
+if Iterable <= Integer or Iterable <= Integer[0, default] or Iterable <= Integer[default, 10] {
+    fail incorrect
+}
+
+if Iterable <= Integer[0, 10] or Iterable[Integer] <= Integer[0, 10] {
+    fail incorrect
+}
+
+if Iterable[String] <= Integer[0, 10] or Iterable[Integer[0, 10]] <= Integer[20, 30] {
+    fail incorrect
+}
+
+if Iterable <= Enum {
+    fail incorrect
+}
+
+if Iterable[String] <= Enum[foo] {
+    fail incorrect
+}
+
+if Iterable[Integer] <= Enum[foo] {
+    fail incorrect
+}
+
+if Iterable <= Iterator {
+    fail incorrect
+}
+
+if Iterable[Numeric] <= Iterator[Integer] {
+    fail incorrect
+}
+
+if Iterable[Integer] <= Iterator[String] {
+    fail incorrect
+}
 
 # TODO: add Iterator tests
 

--- a/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
+++ b/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
@@ -1409,7 +1409,75 @@ if Iterable[Integer] <= Iterator[String] {
     fail incorrect
 }
 
-# TODO: add Iterator tests
+# Iterator tests
+
+unless Iterator == Iterator and Iterator[String] == Iterator[String] and Iterator[Integer] != Iterator[Numeric] {
+    fail incorrect
+}
+
+if Iterator > Iterator {
+    fail incorrect
+}
+
+if Iterator[String] > Iterator[String] {
+    fail incorrect
+}
+
+if Iterator[String] > Iterator {
+    fail incorrect
+}
+
+unless Iterator[Numeric] > Iterator[Integer] {
+    fail incorrect
+}
+
+unless Iterator >= Iterator {
+    fail incorrect
+}
+
+unless Iterator[String] >= Iterator[String] {
+    fail incorrect
+}
+
+if Iterator[String] >= Iterator {
+    fail incorrect
+}
+
+unless Iterator[Numeric] >= Iterator[Integer] {
+    fail incorrect
+}
+
+if Iterator < Iterator {
+    fail incorrect
+}
+
+if Iterator[String] < Iterator[String] {
+    fail incorrect
+}
+
+unless Iterator[String] < Iterator {
+    fail incorrect
+}
+
+if Iterator[Numeric] < Iterator[Integer] {
+    fail incorrect
+}
+
+unless Iterator <= Iterator {
+    fail incorrect
+}
+
+unless Iterator[String] <= Iterator[String] {
+    fail incorrect
+}
+
+unless Iterator[String] <= Iterator {
+    fail incorrect
+}
+
+if Iterator[Numeric] <= Iterator[Integer] {
+    fail incorrect
+}
 
 # Numeric tests
 


### PR DESCRIPTION
This implements the `reverse_each` function.

This behaves a little differently from the Ruby implementation in that `reverse_each` has the same signature as `each`, but simply iterates in reverse.  Thus it preserves the "iterate with index", "iterate value" and "iterate key, value" (Hash) semantics of `each`.

The difference in behavior can be viewed as `reverse_each` having a new overload that takes a two-parameter block; if a one-parameter block is passed (the only signature currently supported in the Ruby implementation), then the behavior is identical.