### PR TITLE
(NPUP-39) Implement is_assignable for all types in the type system.

### DIFF
--- a/lib/include/puppet/runtime/types/alias.hpp
+++ b/lib/include/puppet/runtime/types/alias.hpp
@@ -10,6 +10,9 @@
 
 namespace puppet { namespace runtime { namespace types {
 
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
+
     /**
      * Represents a Puppet type alias.
      */
@@ -37,23 +40,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -97,5 +95,91 @@ namespace puppet { namespace runtime { namespace types {
      * @return Returns the hash value for the type.
      */
     size_t hash_value(alias const& type);
+
+    /**
+     * Responsible for guarding against type alias recursion.
+     */
+    struct recursion_guard
+    {
+        /**
+         * Represents the recursion guard map key.
+          */
+        struct key
+        {
+            /**
+             * Constructs a recursion guard map key.
+             * @param alias The type alias being guarded.
+             * @param other The pointer to the other thing being compared against; nullptr if the alias is not being compared to something else.
+             */
+            explicit key(types::alias const& alias, void const* other = nullptr);
+
+            /**
+             * Gets the alias' resolved type.
+             * @return Returns the alias' resolved type.
+             */
+            values::type const& resolved() const;
+
+            /**
+             *  Gets the other thing the alias is being compared to.
+             *  @return Returns the other thing the alias is being compared to or nullptr if not being compared.
+             */
+            void const* other() const;
+
+         private:
+            values::type const& _resolved;
+            void const* _other;
+        };
+
+        /**
+         * The map type for the recursion guard.
+         */
+        using map_type = std::unordered_map<key, bool, boost::hash<key>>;
+
+        /**
+         * Represents the result when adding an alias to the guard.
+         */
+        struct result
+        {
+            /**
+             * Gets whether or not the type alias was recursed.
+             * @return Returns true if the type alias was recursed or false if not.
+             */
+            bool recursed() const;
+
+            /**
+             * Gets the current result value.
+             * @return Returns the current result value.
+             */
+            bool value() const;
+
+            /**
+             * Sets the current result value for the alias.
+             * @param val The new result value for the alias.
+             */
+            void value(bool val);
+
+         private:
+            friend struct recursion_guard;
+            result(map_type::iterator iterator, bool recursed);
+
+            map_type::iterator _iterator;
+            bool _recursed;
+        };
+
+        /**
+         * Adds an alias to the guard.
+         * @param alias The alias to add.
+         * @param other The other thing being compared against; nullptr to indicate the type alias is not being compared against.
+         * @return Returns a result object.
+         */
+        result add(types::alias const& alias, void const* other = nullptr);
+
+     private:
+        map_type _map;
+    };
+
+    bool operator==(recursion_guard::key const& left, recursion_guard::key const& right);
+    size_t hash_value(recursion_guard::key const& key);
+
 
 }}}  // namespace puppet::runtime::types

--- a/lib/include/puppet/runtime/types/any.hpp
+++ b/lib/include/puppet/runtime/types/any.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Any type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/array.hpp
+++ b/lib/include/puppet/runtime/types/array.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <limits>
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Array type.
@@ -25,7 +24,7 @@ namespace puppet { namespace runtime { namespace types {
          * @param from The "from" type parameter.
          * @param to The "to" type parameter.
          */
-        explicit array(std::unique_ptr<values::type> type = nullptr, int64_t from = std::numeric_limits<int64_t>::min(), int64_t to = std::numeric_limits<int64_t>::max());
+        explicit array(std::unique_ptr<values::type> type = nullptr, int64_t from = 0, int64_t to = std::numeric_limits<int64_t>::max());
 
         /**
          * Copy constructor for array type.
@@ -80,23 +79,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -104,6 +98,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static array const instance;
 
      private:
         std::unique_ptr<values::type> _element_type;

--- a/lib/include/puppet/runtime/types/boolean.hpp
+++ b/lib/include/puppet/runtime/types/boolean.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Boolean type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -51,6 +45,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static boolean const instance;
     };
 
     /**

--- a/lib/include/puppet/runtime/types/callable.hpp
+++ b/lib/include/puppet/runtime/types/callable.hpp
@@ -10,7 +10,6 @@
 #include <ostream>
 #include <vector>
 #include <limits>
-#include <unordered_map>
 
 namespace puppet { namespace compiler { namespace evaluation { namespace functions {
 
@@ -21,8 +20,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Callable type.
@@ -114,23 +113,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/catalog_entry.hpp
+++ b/lib/include/puppet/runtime/types/catalog_entry.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet CatalogEntry type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/class.hpp
+++ b/lib/include/puppet/runtime/types/class.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Class type.
@@ -45,23 +44,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -76,7 +70,12 @@ namespace puppet { namespace runtime { namespace types {
          */
         static void normalize(std::string& name);
 
-    private:
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static klass const instance;
+
+     private:
         std::string _title;
     };
 

--- a/lib/include/puppet/runtime/types/collection.hpp
+++ b/lib/include/puppet/runtime/types/collection.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <ostream>
 #include <limits>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Collection type.
@@ -24,7 +23,7 @@ namespace puppet { namespace runtime { namespace types {
          * @param from The "from" type parameter.
          * @param to The "to" type parameter.
          */
-        explicit collection(int64_t from = std::numeric_limits<int64_t>::min(), int64_t to = std::numeric_limits<int64_t>::max());
+        explicit collection(int64_t from = 0, int64_t to = std::numeric_limits<int64_t>::max());
 
         /**
          * Gets the "from" type parameter.
@@ -47,23 +46,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/data.hpp
+++ b/lib/include/puppet/runtime/types/data.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Data type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/defaulted.hpp
+++ b/lib/include/puppet/runtime/types/defaulted.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Default type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/enumeration.hpp
+++ b/lib/include/puppet/runtime/types/enumeration.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <ostream>
 #include <vector>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Enum type.
@@ -40,23 +39,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/floating.hpp
+++ b/lib/include/puppet/runtime/types/floating.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <ostream>
 #include <limits>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Float type.
@@ -47,23 +46,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -71,6 +65,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static floating const instance;
 
      private:
         double _from;

--- a/lib/include/puppet/runtime/types/integer.hpp
+++ b/lib/include/puppet/runtime/types/integer.hpp
@@ -9,12 +9,11 @@
 #include <limits>
 #include <cstdint>
 #include <functional>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Integer[from, to] type.
@@ -61,23 +60,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -85,6 +79,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static integer const instance;
 
      private:
         int64_t _from;

--- a/lib/include/puppet/runtime/types/iterable.hpp
+++ b/lib/include/puppet/runtime/types/iterable.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Iterable type.
@@ -65,23 +64,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/iterator.hpp
+++ b/lib/include/puppet/runtime/types/iterator.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Iterator type.
@@ -65,23 +64,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/not_undef.hpp
+++ b/lib/include/puppet/runtime/types/not_undef.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet NotUndef type.
@@ -65,23 +64,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/numeric.hpp
+++ b/lib/include/puppet/runtime/types/numeric.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Numeric type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -51,6 +45,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static numeric const instance;
     };
 
     /**

--- a/lib/include/puppet/runtime/types/optional.hpp
+++ b/lib/include/puppet/runtime/types/optional.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Optional type.
@@ -65,23 +64,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/pattern.hpp
+++ b/lib/include/puppet/runtime/types/pattern.hpp
@@ -8,12 +8,11 @@
 #include "../values/regex.hpp"
 #include <ostream>
 #include <vector>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Pattern type.
@@ -41,23 +40,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/regexp.hpp
+++ b/lib/include/puppet/runtime/types/regexp.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Regexp type.
@@ -39,23 +38,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -63,6 +57,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static regexp const instance;
 
      private:
         std::string _pattern;

--- a/lib/include/puppet/runtime/types/resource.hpp
+++ b/lib/include/puppet/runtime/types/resource.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <boost/optional.hpp>
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Resource type.
@@ -72,23 +71,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -103,6 +97,11 @@ namespace puppet { namespace runtime { namespace types {
          * @return Returns the resource type if successful or boost::none if parsing was unsuccessful.
          */
         static boost::optional<resource> parse(std::string const& specification);
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static resource const instance;
 
      private:
         std::string _type_name;

--- a/lib/include/puppet/runtime/types/runtime.hpp
+++ b/lib/include/puppet/runtime/types/runtime.hpp
@@ -8,7 +8,6 @@
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace compiler { namespace evaluation { namespace collectors {
 
@@ -19,8 +18,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace collect
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Runtime type.
@@ -76,23 +75,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/scalar.hpp
+++ b/lib/include/puppet/runtime/types/scalar.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Scalar type.
@@ -27,23 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -51,6 +45,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static scalar const instance;
     };
 
     /**

--- a/lib/include/puppet/runtime/types/string.hpp
+++ b/lib/include/puppet/runtime/types/string.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <limits>
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     // Forward declaration of integer
     struct integer;
@@ -27,7 +26,7 @@ namespace puppet { namespace runtime { namespace types {
          * @param from The "from" type parameter.
          * @param to The "to" type parameter.
          */
-        explicit string(int64_t from = std::numeric_limits<int64_t>::min(), int64_t to = std::numeric_limits<int64_t>::max());
+        explicit string(int64_t from = 0, int64_t to = std::numeric_limits<int64_t>::max());
 
         /**
          * Constructs a string from an integer range.
@@ -56,22 +55,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
-        /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
-         */
-        bool is_specialization(values::type const& other) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -79,6 +74,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static string const instance;
 
      private:
         int64_t _from;

--- a/lib/include/puppet/runtime/types/struct.hpp
+++ b/lib/include/puppet/runtime/types/struct.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <ostream>
 #include <vector>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Struct type.
@@ -71,23 +70,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -96,9 +90,14 @@ namespace puppet { namespace runtime { namespace types {
          */
         void write(std::ostream& stream, bool expand = true) const;
 
-     private:
-        static std::string to_key(values::type const& type);
+        /**
+         * Gets the string representation of a schema key type.
+         * @param type The key type to get the key string for.
+         * @return Returns the key represented as a string or an empty string if the key is the expected type.
+         */
+        static std::string const& to_key(values::type const& type);
 
+     private:
         schema_type _schema;
     };
 

--- a/lib/include/puppet/runtime/types/tuple.hpp
+++ b/lib/include/puppet/runtime/types/tuple.hpp
@@ -9,12 +9,11 @@
 #include <vector>
 #include <cstdint>
 #include <limits>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Tuple type.
@@ -85,23 +84,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -109,6 +103,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static tuple const instance;
 
      private:
         std::vector<std::unique_ptr<values::type>> _types;

--- a/lib/include/puppet/runtime/types/type.hpp
+++ b/lib/include/puppet/runtime/types/type.hpp
@@ -9,8 +9,8 @@
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Type type.
@@ -64,23 +64,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.

--- a/lib/include/puppet/runtime/types/undef.hpp
+++ b/lib/include/puppet/runtime/types/undef.hpp
@@ -6,12 +6,11 @@
 
 #include "../values/forward.hpp"
 #include <ostream>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Undef type.
@@ -27,22 +26,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
-        /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
-         */
-        bool is_specialization(values::type const& other) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -50,6 +45,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static undef const instance;
     };
 
     /**

--- a/lib/include/puppet/runtime/types/variant.hpp
+++ b/lib/include/puppet/runtime/types/variant.hpp
@@ -7,12 +7,11 @@
 #include "../values/forward.hpp"
 #include <ostream>
 #include <vector>
-#include <unordered_map>
 
 namespace puppet { namespace runtime { namespace types {
 
-    // Forward declaration of alias
-    struct alias;
+    // Forward declaration of recursion_guard
+    struct recursion_guard;
 
     /**
      * Represents the Puppet Variant type.
@@ -66,23 +65,18 @@ namespace puppet { namespace runtime { namespace types {
         /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
+         * @param guard The recursion guard to use for aliases.
          * @return Returns true if the given value is an instance of this type or false if not.
          */
-        bool is_instance(values::value const& value) const;
+        bool is_instance(values::value const& value, recursion_guard& guard) const;
 
         /**
-         * Determines if the given type is a specialization (i.e. more specific) of this type.
-         * @param other The other type to check for specialization.
-         * @return Returns true if the other type is a specialization or false if not.
+         * Determines if the given type is assignable to this type.
+         * @param other The other type to check for assignability.
+         * @param guard The recursion guard to use for aliases.
+         * @return Returns true if the given type is assignable to this type or false if the given type is not assignable to this type.
          */
-        bool is_specialization(values::type const& other) const;
-
-        /**
-         * Determines if the type is real (i.e. actual type vs. an alias/variant that never resolves to an actual type).
-         * @param map The map to keep track of encountered type aliases.
-         * @return Returns true if the type is real or false if it never resolves to an actual type.
-         */
-        bool is_real(std::unordered_map<values::type const*, bool>& map) const;
+        bool is_assignable(values::type const& other, recursion_guard& guard) const;
 
         /**
          * Writes a representation of the type to the given stream.
@@ -92,7 +86,6 @@ namespace puppet { namespace runtime { namespace types {
         void write(std::ostream& stream, bool expand = true) const;
 
     private:
-        bool is_self_referencing(values::type const& type) const;
         std::vector<std::unique_ptr<values::type>> _types;
     };
 

--- a/lib/include/puppet/runtime/values/hash.hpp
+++ b/lib/include/puppet/runtime/values/hash.hpp
@@ -238,7 +238,7 @@ namespace puppet { namespace runtime { namespace values {
 
         struct indirect_comparer
         {
-            bool operator()(values::value const* right, values::value const* left) const;
+            bool operator()(values::value const* left, values::value const* right) const;
         };
 
         sequence_type _elements;

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -387,7 +387,7 @@ namespace puppet { namespace runtime { namespace values {
         }
 
         /**
-         * Compares two different value types.
+         * Compares two value types.
          * @tparam T The type of the values being compared.
          * @param left The left hand value.
          * @param right The right hand value.

--- a/lib/include/puppet/runtime/values/variable.hpp
+++ b/lib/include/puppet/runtime/values/variable.hpp
@@ -73,7 +73,7 @@ namespace puppet { namespace runtime { namespace values {
      * @param right The right variable to compare.
      * @return Returns true if variables are not equal or false if they are equal.
      */
-    bool operator==(type const& left, type const& right);
+    bool operator!=(variable const& left, variable const& right);
 
     /**
      * Hashes the variable value.

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -569,6 +569,25 @@ namespace puppet { namespace compiler { namespace evaluation {
             return types::tuple(rvalue_cast(types), from, to);
         }
 
+        value operator()(collection const& target)
+        {
+            // At most 2 arguments to Collection
+            if (_arguments.size() > 2) {
+                throw evaluation_exception(
+                    (boost::format("expected at most 2 arguments for %1% but %2% were given.") %
+                     collection::name() %
+                     _arguments.size()
+                    ).str(),
+                    _contexts[2],
+                    _context.backtrace()
+                );
+            }
+
+            int64_t from, to;
+            tie(from, to) = get_range<int64_t, integer>(true);
+            return collection(from, to);
+        }
+
         value operator()(optional const& target)
         {
             // Only 1 argument to Optional

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -248,7 +248,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      types::iterable::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -276,7 +276,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      types::iterator::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -329,7 +329,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             }
 
             int64_t from, to;
-            tie(from, to) = get_range<int64_t, integer>(true);
+            tie(from, to) = get_range<int64_t, integer>(true, 0, 0);
             return types::string(from, to);
         }
 
@@ -466,7 +466,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // Get the optional range
             size_t from, to;
-            tie(from, to) = get_range<int64_t, integer>(true, 1);
+            tie(from, to) = get_range<int64_t, integer>(true, 1, 0);
             return types::array(make_unique<values::type>(_arguments[0]->move_as<values::type>()), from, to);
         }
 
@@ -520,7 +520,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // Get the optional range
             size_t from, to;
-            tie(from, to) = get_range<int64_t, integer>(true, 2);
+            tie(from, to) = get_range<int64_t, integer>(true, 2, 0);
             return types::hash(
                 make_unique<values::type>(_arguments[0]->move_as<values::type>()),
                 make_unique<values::type>(_arguments[1]->move_as<values::type>()),
@@ -551,7 +551,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                         );
                     }
                     // Get the optional range
-                    tie(from, to) = get_range<int64_t, integer>(false, i, 0, numeric_limits<int64_t>::max());
+                    tie(from, to) = get_range<int64_t, integer>(false, i, 0);
                     break;
                 }
                 types.emplace_back(new values::type(_arguments[i]->move_as<values::type>()));
@@ -584,7 +584,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             }
 
             int64_t from, to;
-            tie(from, to) = get_range<int64_t, integer>(true);
+            tie(from, to) = get_range<int64_t, integer>(true, 0, 0);
             return collection(from, to);
         }
 
@@ -597,7 +597,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      optional::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -632,7 +632,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      optional::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -667,7 +667,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      types::type::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -696,7 +696,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      structure::name() %
                      _arguments.size()
                     ).str(),
-                    _contexts[2],
+                    _contexts[1],
                     _context.backtrace()
                 );
             }
@@ -733,6 +733,8 @@ namespace puppet { namespace compiler { namespace evaluation {
                         if (not_undef->type()) {
                             enumeration = boost::get<types::enumeration>(not_undef->type().get());
                         }
+                    } else {
+                        enumeration = boost::get<types::enumeration>(type);
                     }
                     if (enumeration && enumeration->strings().size() == 1) {
                         key = make_unique<values::type>(*type);
@@ -882,7 +884,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                         );
                     }
                     // Get the optional min/max range
-                    tie(min, max) = get_range<int64_t, integer>(false, i, 0, numeric_limits<int64_t>::max());
+                    tie(min, max) = get_range<int64_t, integer>(false, i, 0);
 
                     // Get the optional block type
                     if (i + 2 < _arguments.size()) {

--- a/lib/src/compiler/evaluation/context.cc
+++ b/lib/src/compiler/evaluation/context.cc
@@ -714,9 +714,8 @@ namespace puppet { namespace compiler { namespace evaluation {
 
         *resolved = rvalue_cast(*type);
 
-        // Ensure the alias resolves to a "real" type
-        unordered_map<values::type const*, bool> map;
-        if (!resolved->is_real(map)) {
+        types::recursion_guard guard;
+        if (!resolved->is_real(guard)) {
             throw evaluation_exception(
                 (boost::format("%1% does not resolve to a real type.") %
                  *resolved

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -852,7 +852,8 @@ namespace puppet { namespace compiler { namespace evaluation {
         }
 
         // Validate the type of the parameter
-        if (type && !type->is_instance(value)) {
+        types::recursion_guard guard;
+        if (type && !type->is_instance(value, guard)) {
             throw evaluation_exception(
                 (boost::format("expected %1% for attribute '%2%' but found %3%.") %
                  *type %
@@ -1084,7 +1085,8 @@ namespace puppet { namespace compiler { namespace evaluation {
                 context.backtrace()
             );
         }
-        if (!type->is_instance(value)) {
+        types::recursion_guard guard;
+        if (!type->is_instance(value, guard)) {
             error((boost::format("parameter $%1% has expected type %2% but was given %3%.") % parameter.variable.name % *type % value.get_type()).str());
         }
     }

--- a/lib/src/compiler/evaluation/functions/assert_type.cc
+++ b/lib/src/compiler/evaluation/functions/assert_type.cc
@@ -12,7 +12,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
     static values::value assert_type_is(call_context& context, values::type const& type)
     {
         auto& instance = context.argument(1);
-        if (type.is_instance(instance)) {
+        types::recursion_guard guard;
+        if (type.is_instance(instance, guard)) {
             return rvalue_cast(instance);
         }
 

--- a/lib/src/compiler/evaluation/operators/binary/equals.cc
+++ b/lib/src/compiler/evaluation/operators/binary/equals.cc
@@ -2,7 +2,7 @@
 #include <puppet/compiler/evaluation/operators/binary/call_context.hpp>
 
 using namespace std;
-using namespace puppet::runtime::values;
+using namespace puppet::runtime;
 
 namespace puppet { namespace compiler { namespace evaluation { namespace operators { namespace binary {
 
@@ -10,6 +10,12 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
     {
         binary::descriptor descriptor{ ast::binary_operator::equals };
 
+        descriptor.add("Type", "Type", [](call_context& context) {
+            auto& left = context.left().require<values::type>();
+            auto& right = context.right().require<values::type>();
+            types::recursion_guard guard;
+            return left == right || (left.is_assignable(right, guard) && right.is_assignable(left, guard));
+        });
         descriptor.add("Any", "Any", [](call_context& context) {
             return context.left() == context.right();
         });

--- a/lib/src/compiler/evaluation/operators/binary/greater.cc
+++ b/lib/src/compiler/evaluation/operators/binary/greater.cc
@@ -30,7 +30,10 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return !boost::ilexicographical_compare(left, right) && !boost::iequals(left, right);
         });
         descriptor.add("Type", "Type", [](call_context& context) {
-            return context.right().require<values::type>().is_specialization(context.left().require<values::type>());
+            auto& left = context.left().require<values::type>();
+            auto& right = context.right().require<values::type>();
+            types::recursion_guard guard;
+            return left.is_assignable(right, guard) && left != right && !right.is_assignable(left, guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/binary/greater_equal.cc
+++ b/lib/src/compiler/evaluation/operators/binary/greater_equal.cc
@@ -32,7 +32,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         descriptor.add("Type", "Type", [](call_context& context) {
             auto& left = context.left().require<values::type>();
             auto& right = context.right().require<values::type>();
-            return left == right || right.is_specialization(left);
+            types::recursion_guard guard;
+            return left.is_assignable(right, guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/binary/in.cc
+++ b/lib/src/compiler/evaluation/operators/binary/in.cc
@@ -29,8 +29,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         descriptor.add("Type", "Array[Any]", [](call_context& context) {
             auto& left = context.left().require<values::type>();
             auto& right = context.right().require<values::array>();
+            types::recursion_guard guard;
             for (auto const& element : right) {
-                if (left.is_instance(element)) {
+                if (left.is_instance(element, guard)) {
                     return true;
                 }
             }
@@ -60,8 +61,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         descriptor.add("Type", "Hash[Any, Any]", [](call_context& context) {
             auto& left = context.left().require<values::type>();
             auto& right = context.right().require<values::hash>();
+            types::recursion_guard guard;
             for (auto const& kvp : right) {
-                if (left.is_instance(kvp.key())) {
+                if (left.is_instance(kvp.key(), guard)) {
                     return true;
                 }
             }

--- a/lib/src/compiler/evaluation/operators/binary/less.cc
+++ b/lib/src/compiler/evaluation/operators/binary/less.cc
@@ -27,7 +27,10 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return boost::ilexicographical_compare(context.left().require<string>(), context.right().require<string>());
         });
         descriptor.add("Type", "Type", [](call_context& context) {
-            return context.left().require<values::type>().is_specialization(context.right().require<values::type>());
+            auto& left = context.left().require<values::type>();
+            auto& right = context.right().require<values::type>();
+            types::recursion_guard guard;
+            return right.is_assignable(left, guard) && left != right && !left.is_assignable(right, guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/binary/less_equal.cc
+++ b/lib/src/compiler/evaluation/operators/binary/less_equal.cc
@@ -31,7 +31,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
         descriptor.add("Type", "Type", [](call_context& context) {
             auto& left = context.left().require<values::type>();
             auto& right = context.right().require<values::type>();
-            return left == right || left.is_specialization(right);
+            types::recursion_guard guard;
+            return right.is_assignable(left, guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/binary/match.cc
+++ b/lib/src/compiler/evaluation/operators/binary/match.cc
@@ -47,7 +47,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return is_match(context, context.left().require<string>(), context.right().require<values::regex>());
         });
         descriptor.add("Any", "Type", [](call_context& context) {
-            return context.right().require<values::type>().is_instance(context.left());
+            types::recursion_guard guard;
+            return context.right().require<values::type>().is_instance(context.left(), guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/binary/not_equals.cc
+++ b/lib/src/compiler/evaluation/operators/binary/not_equals.cc
@@ -10,6 +10,12 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
     {
         binary::descriptor descriptor{ ast::binary_operator::not_equals };
 
+        descriptor.add("Type", "Type", [](call_context& context) {
+            auto& left = context.left().require<values::type>();
+            auto& right = context.right().require<values::type>();
+            types::recursion_guard guard;
+            return left != right && (!left.is_assignable(right, guard) || !right.is_assignable(left, guard));
+        });
         descriptor.add("Any", "Any", [](call_context& context) {
             return context.left() != context.right();
         });

--- a/lib/src/compiler/evaluation/operators/binary/not_match.cc
+++ b/lib/src/compiler/evaluation/operators/binary/not_match.cc
@@ -21,7 +21,8 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             return !is_match(context, context.left().require<string>(), context.right().require<values::regex>());
         });
         descriptor.add("Any", "Type", [](call_context& context) {
-            return !context.right().require<values::type>().is_instance(context.left());
+            types::recursion_guard guard;
+            return !context.right().require<values::type>().is_instance(context.left(), guard);
         });
         return descriptor;
     }

--- a/lib/src/compiler/evaluation/operators/unary/descriptor.cc
+++ b/lib/src/compiler/evaluation/operators/unary/descriptor.cc
@@ -40,8 +40,9 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
     {
         // Search for a dispatch descriptor with a matching operand type
         // TODO: in the future, this should dispatch to the most specific overload rather than the first dispatchable overload
+        types::recursion_guard guard;
         for (auto& descriptor : _dispatch_descriptors) {
-            if (descriptor.type.is_instance(context.operand())) {
+            if (descriptor.type.is_instance(context.operand(), guard)) {
                 return descriptor.callback(context);
             }
         }

--- a/lib/src/runtime/types/alias.cc
+++ b/lib/src/runtime/types/alias.cc
@@ -24,28 +24,42 @@ namespace puppet { namespace runtime { namespace types {
         return *_resolved_type;
     }
 
-    bool alias::is_instance(values::value const& value) const
+    bool alias::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        return _resolved_type->is_instance(value);
+        auto result = guard.add(*this, &value);
+        if (result.recursed()) {
+            return result.value();
+        }
+        result.value(_resolved_type->is_instance(value, guard));
+        return result.value();
     }
 
-    bool alias::is_specialization(values::type const& other) const
+    bool alias::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // No specializations of type aliases
-        return false;
-    }
+        if (auto alias = boost::get<types::alias>(&other.get())) {
+            auto target = &alias->_resolved_type->dereference();
 
-    bool alias::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // If the alias was already encountered, return the result
-        auto it = map.find(_resolved_type.get());
-        if (it != map.end()) {
-            return it->second;
+            // Aliases are assignable if they ultimately point at the same resolved type
+            if (&_resolved_type->dereference() == target) {
+                return true;
+            }
+            // Check if this alias refers to a variant that may contain an alias that resolves to the other alias
+            if (auto variant = boost::get<types::variant>(_resolved_type.get())) {
+                for (auto& t : variant->types()) {
+                    if (&t->dereference() == target) {
+                        return true;
+                    }
+                }
+            }
         }
 
-        // Pretend it is not real until we determine that the resolved type is real
-        it = map.emplace(_resolved_type.get(), false).first;
-        return (it->second = _resolved_type->is_real(map));
+        // Recurse on the resolved type
+        auto result = guard.add(*this, &other);
+        if (result.recursed()) {
+            return result.value();
+        }
+        result.value(_resolved_type->is_assignable(other, guard));
+        return result.value();
     }
 
     void alias::write(ostream& stream, bool expand) const
@@ -82,6 +96,65 @@ namespace puppet { namespace runtime { namespace types {
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
         boost::hash_combine(seed, type.name());
+        return seed;
+    }
+
+    recursion_guard::key::key(types::alias const& alias, void const* other) :
+        _resolved(alias.resolved_type()),
+        _other(other)
+    {
+    }
+
+    values::type const& recursion_guard::key::resolved() const
+    {
+        return _resolved;
+    }
+
+    void const* recursion_guard::key::other() const
+    {
+        return _other;
+    }
+
+    bool recursion_guard::result::recursed() const
+    {
+        return _recursed;
+    }
+
+    bool recursion_guard::result::value() const
+    {
+        return _iterator->second;
+    }
+
+    void recursion_guard::result::value(bool val)
+    {
+        _iterator->second = val;
+    }
+
+    recursion_guard::result::result(recursion_guard::map_type::iterator iterator, bool recursed) :
+        _iterator(rvalue_cast(iterator)),
+        _recursed(recursed)
+    {
+    }
+
+    recursion_guard::result recursion_guard::add(types::alias const& alias, void const* other)
+    {
+        auto result = _map.emplace(key{ alias, other }, false);
+        return { rvalue_cast(result.first), !result.second };
+    }
+
+    bool operator==(recursion_guard::key const& left, recursion_guard::key const& right)
+    {
+        return &left.resolved() == &right.resolved() && left.other() == right.other();
+    }
+
+    size_t hash_value(recursion_guard::key const& key)
+    {
+        size_t seed = 0;
+        // Just use the addresses
+        boost::hash_combine(seed, &key.resolved());
+        if (key.other()) {
+            boost::hash_combine(seed, key.other());
+        }
         return seed;
     }
 

--- a/lib/src/runtime/types/any.cc
+++ b/lib/src/runtime/types/any.cc
@@ -10,21 +10,15 @@ namespace puppet { namespace runtime { namespace types {
         return "Any";
     }
 
-    bool any::is_instance(values::value const& value) const
+    bool any::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // All values are an instance of Any
         return true;
     }
 
-    bool any::is_specialization(values::type const& other) const
+    bool any::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // All types (except for Any) are specializations of Any
-        return !boost::get<any>(&other);
-    }
-
-    bool any::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Any is a real type
+        // All types are assignable to Any
         return true;
     }
 

--- a/lib/src/runtime/types/boolean.cc
+++ b/lib/src/runtime/types/boolean.cc
@@ -5,26 +5,21 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    boolean const boolean::instance{};
+
     char const* boolean::name()
     {
         return "Boolean";
     }
 
-    bool boolean::is_instance(values::value const& value) const
+    bool boolean::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.as<bool>();
     }
 
-    bool boolean::is_specialization(values::type const& other) const
+    bool boolean::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // No specializations for Boolean
-        return false;
-    }
-
-    bool boolean::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Boolean is a real type
-        return true;
+        return boost::get<boolean>(&other);
     }
 
     void boolean::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/callable.cc
+++ b/lib/src/runtime/types/callable.cc
@@ -266,10 +266,11 @@ namespace puppet { namespace runtime { namespace types {
             }
         }
         // Check the block
-        if ((left.block_type() && !right.block_type()) ||
-            (!left.block_type() && right.block_type()) ||
-            *left.block_type() != *right.block_type()) {
-            return false;
+        if (left.block_type() || right.block_type()) {
+            if (!left.block_type() || !right.block_type()) {
+                return false;
+            }
+            return *left.block_type() == *right.block_type();
         }
         return true;
     }
@@ -285,7 +286,9 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        boost::hash_range(seed, type.types().begin(), type.types().end());
+        for (auto& t : type.types()) {
+            boost::hash_combine(seed, *t);
+        }
         boost::hash_combine(seed, type.min());
         boost::hash_combine(seed, type.max());
         if (type.block_type()) {

--- a/lib/src/runtime/types/callable.cc
+++ b/lib/src/runtime/types/callable.cc
@@ -87,50 +87,52 @@ namespace puppet { namespace runtime { namespace types {
         return "Callable";
     }
 
-    bool callable::is_instance(values::value const& value) const
+    bool callable::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        // Currently functions cannot be represented as a value,
-        // This will need to change once functions can be properly treated as a value.
+        // Currently functions cannot be represented as a value.
         return false;
     }
 
-    bool callable::is_specialization(values::type const& other) const
+    bool callable::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Check for another Callable
         auto ptr = boost::get<callable>(&other);
         if (!ptr) {
             return false;
         }
 
-        // Check for less types (i.e. this type is more specialized)
-        auto& other_types = ptr->types();
-        if (other_types.size() < _types.size()) {
+        // Check to see if this type is simply Callable; if so, the other is always assignable
+        if (_types.empty() && _min == 0 && _max == numeric_limits<int64_t>::max() && !_block_type) {
+            return true;
+        }
+
+        if (std::min(ptr->min(), ptr->max()) < std::min(_min, _max) ||
+            std::max(ptr->min(), ptr->max()) > std::max(_min, _max)) {
             return false;
         }
-        // All types must match
-        for (size_t i = 0; i < _types.size(); ++i) {
-            if (*_types[i] != *other_types[i]) {
+
+        // Ensure that the other Callable's types are assignable to this one's.
+        // This is intentionally backwards because Callable only accepts types that it can be invoked with.
+        // Thus, Callable[Numeric] cannot be assigned to Callable[Any] (Any is not assignable to Numeric), but
+        // Callable[Numeric] can be assigned to Callable[Integer] (Integer is assignable to Numeric).
+        size_t i = 0;
+        for (auto& type : ptr->_types) {
+            if (i >= _types.size()) {
+                break;
+            }
+
+            if (!type->is_assignable(*_types[i++], guard)) {
                 return false;
             }
         }
 
-        // The blocks must match
-        if ((_block_type && !ptr->_block_type) || (!_block_type && ptr->_block_type) || (*_block_type != *ptr->_block_type)) {
-            return false;
+        if (_block_type || ptr->_block_type) {
+            if (!_block_type || !ptr->_block_type) {
+                return false;
+            }
+            if (!ptr->_block_type->is_assignable(*_block_type, guard)) {
+                return false;
+            }
         }
-
-        // Check for equality
-        if (_min == ptr->min() && _max == ptr->max()) {
-            return false;
-        }
-        // Check for a more specialized min/max
-        return std::min(ptr->min(), ptr->max()) >= std::min(_min, _max) &&
-               std::max(ptr->min(), ptr->max()) <= std::max(_min, _max);
-    }
-
-    bool callable::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Callable is a real type
         return true;
     }
 
@@ -219,10 +221,11 @@ namespace puppet { namespace runtime { namespace types {
         }
 
         // Check the argument types
+        types::recursion_guard guard;
         auto argument_count = static_cast<int64_t>(arguments.size());
         for (int64_t i = 0; i < argument_count; ++i) {
             // Ensure the argument is of the specified type
-            if (!parameter_type(i)->is_instance(arguments[i])) {
+            if (!parameter_type(i)->is_instance(arguments[i], guard)) {
                 return i;
             }
         }

--- a/lib/src/runtime/types/catalog_entry.cc
+++ b/lib/src/runtime/types/catalog_entry.cc
@@ -11,22 +11,17 @@ namespace puppet { namespace runtime { namespace types {
         return "CatalogEntry";
     }
 
-    bool catalog_entry::is_instance(values::value const& value) const
+    bool catalog_entry::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        return resource().is_instance(value) || klass().is_instance(value);
+        return resource::instance.is_instance(value, guard) || klass::instance.is_instance(value, guard);
     }
 
-    bool catalog_entry::is_specialization(values::type const& other) const
+    bool catalog_entry::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Resource and Class types are specializations
-        return boost::get<resource>(&other) ||
-               boost::get<klass>(&other);
-    }
-
-    bool catalog_entry::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // CatalogEntry is a real type
-        return true;
+        if (boost::get<catalog_entry>(&other)) {
+            return true;
+        }
+        return resource::instance.is_assignable(other, guard) || klass::instance.is_assignable(other, guard);
     }
 
     void catalog_entry::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/data.cc
+++ b/lib/src/runtime/types/data.cc
@@ -5,32 +5,23 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
-    bool data::is_instance(values::value const& value) const
+    bool data::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        // Data is scalar, array, hash, or undef
-        return scalar().is_instance(value) ||
-               array().is_instance(value)  ||
-               hash().is_instance(value)   ||
-               undef().is_instance(value);
+        return scalar::instance.is_instance(value, guard) || array::instance.is_instance(value, guard) ||
+               hash::instance.is_instance(value, guard)   || undef::instance.is_instance(value, guard);
     }
 
-    bool data::is_specialization(values::type const& other) const
+    bool data::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Scalar, Array, Hash, and Undef are specializations of Data
-        // Also specializations of Scalar, Array, and Hash
-        return boost::get<scalar>(&other) ||
-               boost::get<array>(&other) ||
-               boost::get<hash>(&other) ||
-               boost::get<undef>(&other) ||
-               scalar().is_specialization(other) ||
-               array().is_specialization(other) ||
-               hash().is_specialization(other);
-    }
-
-    bool data::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Data is a real type
-        return true;
+        if (boost::get<data>(&other)) {
+            return true;
+        }
+        if (scalar::instance.is_assignable(other, guard) || array::instance.is_assignable(other, guard)  ||
+            hash::instance.is_assignable(other, guard)   || undef::instance.is_assignable(other, guard)  ||
+            tuple::instance.is_assignable(other, guard)) {
+            return true;
+        }
+        return false;
     }
 
     void data::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/defaulted.cc
+++ b/lib/src/runtime/types/defaulted.cc
@@ -10,21 +10,14 @@ namespace puppet { namespace runtime { namespace types {
         return "Default";
     }
 
-    bool defaulted::is_instance(values::value const& value) const
+    bool defaulted::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.is_default();
     }
 
-    bool defaulted::is_specialization(values::type const& other) const
+    bool defaulted::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // No specializations of Default
-        return false;
-    }
-
-    bool defaulted::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Default is a real type
-        return true;
+        return boost::get<defaulted>(&other);
     }
 
     void defaulted::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/floating.cc
+++ b/lib/src/runtime/types/floating.cc
@@ -5,6 +5,8 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    floating const floating::instance;
+
     floating::floating(double from, double to) :
         _from(from),
         _to(to)
@@ -26,7 +28,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Float";
     }
 
-    bool floating::is_instance(values::value const& value) const
+    bool floating::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<double>();
         if (!ptr) {
@@ -35,25 +37,14 @@ namespace puppet { namespace runtime { namespace types {
         return _to < _from ? (*ptr >= _to && *ptr <= _from) : (*ptr >= _from && *ptr <= _to);
     }
 
-    bool floating::is_specialization(values::type const& other) const
+    bool floating::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Check for an Float with a range inside of this type's range
         auto ptr = boost::get<floating>(&other);
         if (!ptr) {
             return false;
         }
-        // Check for equality
-        if (ptr->from() == _from && ptr->to() == _to) {
-            return false;
-        }
-        return std::min(ptr->from(), ptr->to()) >= std::min(_from, _to) &&
-               std::max(ptr->from(), ptr->to()) <= std::max(_from, _to);
-    }
-
-    bool floating::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Float is a real type
-        return true;
+        return std::min(ptr->_from, ptr->_to) >= std::min(_from, _to) &&
+               std::max(ptr->_from, ptr->_to) <= std::max(_from, _to);
     }
 
     void floating::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/integer.cc
+++ b/lib/src/runtime/types/integer.cc
@@ -5,6 +5,8 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    integer const integer::instance;
+
     integer::integer(int64_t from, int64_t to) :
         _from(from),
         _to(to)
@@ -49,7 +51,7 @@ namespace puppet { namespace runtime { namespace types {
         }
     }
 
-    bool integer::is_instance(values::value const& value) const
+    bool integer::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<int64_t>();
         if (!ptr) {
@@ -58,25 +60,15 @@ namespace puppet { namespace runtime { namespace types {
         return _to < _from ? (*ptr >= _to && *ptr <= _from) : (*ptr >= _from && *ptr <= _to);
     }
 
-    bool integer::is_specialization(values::type const& other) const
+    bool integer::is_assignable(values::type const& other, recursion_guard& guard) const
     {
         // Check for an Integer with a range inside of this type's range
         auto ptr = boost::get<integer>(&other);
         if (!ptr) {
             return false;
         }
-        // Check for equality
-        if (ptr->from() == _from && ptr->to() == _to) {
-            return false;
-        }
         return std::min(ptr->from(), ptr->to()) >= std::min(_from, _to) &&
                std::max(ptr->from(), ptr->to()) <= std::max(_from, _to);
-    }
-
-    bool integer::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Integer is a real type
-        return true;
     }
 
     void integer::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -165,12 +165,13 @@ namespace puppet { namespace runtime { namespace types {
 
     bool operator==(iterable const& left, iterable const& right)
     {
-        if (!left.type() && !right.type()) {
-            return true;
-        } else if (left.type() || right.type()) {
-            return false;
+        if (left.type() || right.type()) {
+            if (!left.type() || !right.type()) {
+                return false;
+            }
+            return *left.type() == *right.type();
         }
-        return *left.type() == *right.type();
+        return true;
     }
 
     bool operator!=(iterable const& left, iterable const& right)

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -31,13 +31,18 @@ namespace puppet { namespace runtime { namespace types {
         return "Iterable";
     }
 
-    bool iterable::is_instance(values::value const& value) const
+    bool iterable::is_instance(values::value const& value, recursion_guard& guard) const
     {
+        // Check for string
+        if (value.as<std::string>()) {
+            return true;
+        }
+
         // Check for array
         if (auto array = value.as<values::array>()) {
             if (_type) {
                 for (auto& element : *array) {
-                    if (!_type->is_instance(*element)) {
+                    if (!_type->is_instance(*element, guard)) {
                         return false;
                     }
                 }
@@ -60,10 +65,7 @@ namespace puppet { namespace runtime { namespace types {
 
                 // Check that all the keys and values are instances of the tuple
                 for (auto& kvp : *hash) {
-                    if (!types[0]->is_instance(kvp.key())) {
-                        return false;
-                    }
-                    if (!types[1]->is_instance(kvp.value())) {
+                    if (!types[0]->is_instance(kvp.key(), guard) || !types[1]->is_instance(kvp.value(), guard)) {
                         return false;
                     }
                 }
@@ -117,9 +119,9 @@ namespace puppet { namespace runtime { namespace types {
                             match = false;
                             return false;
                         }
-                        match = types[0]->is_instance(*key) && types[1]->is_instance(value);
+                        match = types[0]->is_instance(*key, guard) && types[1]->is_instance(value, guard);
                     } else {
-                        match = _type->is_instance(value);
+                        match = _type->is_instance(value, guard);
                     }
                     return match;
                 });
@@ -129,21 +131,53 @@ namespace puppet { namespace runtime { namespace types {
         return false;
     }
 
-    bool iterable::is_specialization(values::type const& other) const
+    bool iterable::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // If this iterable has a specialization, the other iterable cannot be a specialization
-        if (_type) {
-            return false;
+        // Check for string
+        if (boost::get<types::string>(&other)) {
+            return !_type || _type->is_assignable(other, guard);
         }
-        // Check that the other iterable is specialized
-        auto iterable = boost::get<types::iterable>(&other);
-        return iterable && iterable->type();
-    }
-
-    bool iterable::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Iterable is a real type
-        return true;
+        // Check for array
+        if (auto array = boost::get<types::array>(&other)) {
+            return !_type || _type->is_assignable(array->element_type(), guard);
+        }
+        // Check for hash
+        if (auto hash = boost::get<types::hash>(&other)) {
+            if (!_type) {
+                return true;
+            }
+            auto tuple = boost::get<types::tuple>(_type.get());
+            if (!tuple) {
+                return false;
+            }
+            auto& types = tuple->types();
+            if (types.size() != 2) {
+                return false;
+            }
+            return types[0]->is_assignable(hash->key_type(), guard) && types[1]->is_assignable(hash->value_type(), guard);
+        }
+        // Check for Integer
+        if (auto integer = boost::get<types::integer>(&other)) {
+            if (!integer->iterable()) {
+                return false;
+            }
+            return !_type || _type->is_assignable(other, guard);
+        }
+        // Check for Enum
+        if (boost::get<types::enumeration>(&other)) {
+            return !_type || _type->is_assignable(other, guard);
+        }
+        // Check for Iterator
+        if (auto iterator = boost::get<types::iterator>(&other)) {
+            if (!_type) {
+                return true;
+            }
+            if (!iterator->type()) {
+                return false;
+            }
+            return _type->is_assignable(*iterator->type(), guard);
+        }
+        return false;
     }
 
     void iterable::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/iterator.cc
+++ b/lib/src/runtime/types/iterator.cc
@@ -98,12 +98,13 @@ namespace puppet { namespace runtime { namespace types {
 
     bool operator==(iterator const& left, iterator const& right)
     {
-        if (!left.type() && !right.type()) {
-            return true;
-        } else if (left.type() || right.type()) {
-            return false;
+        if (left.type() || right.type()) {
+            if (!left.type() || !right.type()) {
+                return false;
+            }
+            return *left.type() == *right.type();
         }
-        return *left.type() == *right.type();
+        return true;
     }
 
     bool operator!=(iterator const& left, iterator const& right)

--- a/lib/src/runtime/types/iterator.cc
+++ b/lib/src/runtime/types/iterator.cc
@@ -31,7 +31,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Iterator";
     }
 
-    bool iterator::is_instance(values::value const& value) const
+    bool iterator::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto iterator = value.as<values::iterator>();
         if (!iterator) {
@@ -52,9 +52,9 @@ namespace puppet { namespace runtime { namespace types {
                         match = false;
                         return false;
                     }
-                    match = types[0]->is_instance(*key) && types[1]->is_instance(value);
+                    match = types[0]->is_instance(*key, guard) && types[1]->is_instance(value, guard);
                 } else {
-                    match = _type->is_instance(value);
+                    match = _type->is_instance(value, guard);
                 }
                 return match;
             });
@@ -62,21 +62,19 @@ namespace puppet { namespace runtime { namespace types {
         return match;
     }
 
-    bool iterator::is_specialization(values::type const& other) const
+    bool iterator::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // If this iterator has a specialization, the other iterator cannot be a specialization
-        if (_type) {
+        auto iterator = boost::get<types::iterator>(&other);
+        if (!iterator) {
             return false;
         }
-        // Check that the other iterator is specialized
-        auto iterator = boost::get<types::iterator>(&other);
-        return iterator && iterator->type();
-    }
-
-    bool iterator::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Iterator is a real type
-        return true;
+        if (!_type) {
+            return true;
+        }
+        if (!iterator->type()) {
+            return false;
+        }
+        return _type->is_assignable(*iterator->type(), guard);
     }
 
     void iterator::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/not_undef.cc
+++ b/lib/src/runtime/types/not_undef.cc
@@ -32,7 +32,7 @@ namespace puppet { namespace runtime { namespace types {
         return "NotUndef";
     }
 
-    bool not_undef::is_instance(values::value const& value) const
+    bool not_undef::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Undef never matches
         if (value.is_undef()) {
@@ -45,24 +45,17 @@ namespace puppet { namespace runtime { namespace types {
         }
 
         // Check that the instance is of the given type
-        return _type->is_instance(value);
+        return _type->is_instance(value, guard);
     }
 
-    bool not_undef::is_specialization(values::type const& other) const
+    bool not_undef::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // If this type has a specialization, the other type cannot be a specialization
-        if (_type) {
+        // Can never be assigned from Undef
+        if (boost::get<types::undef>(&other)) {
             return false;
         }
-        // Check that the other type is specialized
-        auto not_undef = boost::get<types::not_undef>(&other);
-        return not_undef && not_undef->type();
-    }
 
-    bool not_undef::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // NotUndef is a real type
-        return true;
+        return !_type || _type->is_assignable(other, guard);
     }
 
     void not_undef::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/numeric.cc
+++ b/lib/src/runtime/types/numeric.cc
@@ -5,26 +5,24 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    numeric const numeric::instance{};
+
     char const* numeric::name()
     {
         return "Numeric";
     }
 
-    bool numeric::is_instance(values::value const& value) const
+    bool numeric::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        return value.as<int64_t>() || value.as<double>();
+        return integer::instance.is_instance(value, guard) || floating::instance.is_instance(value, guard);
     }
 
-    bool numeric::is_specialization(values::type const& other) const
+    bool numeric::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Integer or Float is a specialization
-        return boost::get<integer>(&other) || boost::get<floating>(&other);
-    }
-
-    bool numeric::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Numeric is a real type
-        return true;
+        if (boost::get<numeric>(&other)) {
+            return true;
+        }
+        return integer::instance.is_assignable(other, guard) || floating::instance.is_assignable(other, guard);
     }
 
     void numeric::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/regexp.cc
+++ b/lib/src/runtime/types/regexp.cc
@@ -6,6 +6,8 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    regexp const regexp::instance;
+
     regexp::regexp(std::string pattern) :
         _pattern(rvalue_cast(pattern))
     {
@@ -21,7 +23,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Regexp";
     }
 
-    bool regexp::is_instance(values::value const& value) const
+    bool regexp::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<values::regex>();
         if (!ptr) {
@@ -33,21 +35,14 @@ namespace puppet { namespace runtime { namespace types {
         return ptr->pattern() == _pattern;
     }
 
-    bool regexp::is_specialization(values::type const& other) const
+    bool regexp::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // If this Regexp has a pattern, the other type cannot be a specialization
-        if (!_pattern.empty()) {
+        auto regexp = boost::get<types::regexp>(&other);
+        if (!regexp) {
             return false;
         }
-        // Check that the other type has a pattern
-        auto rgx = boost::get<regexp>(&other);
-        return rgx && !rgx->pattern().empty();
-    }
 
-    bool regexp::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Regexp is a real type
-        return true;
+        return _pattern.empty() || _pattern == regexp->_pattern;
     }
 
     void regexp::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/runtime.cc
+++ b/lib/src/runtime/types/runtime.cc
@@ -49,7 +49,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Runtime";
     }
 
-    bool runtime::is_instance(values::value const& value) const
+    bool runtime::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for type
         auto type = value.as<values::type>();
@@ -73,30 +73,13 @@ namespace puppet { namespace runtime { namespace types {
         return _type_name.empty() || _type_name == runtime->type_name();
     }
 
-    bool runtime::is_specialization(values::type const& other) const
+    bool runtime::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Check that the other Runtime is specialized
-        auto type = boost::get<runtime>(&other);
-        if (!type) {
-            // Not the same type
+        auto runtime = boost::get<types::runtime>(&other);
+        if (!runtime) {
             return false;
         }
-        // If this Runtime object has no runtime name, the other is specialized if it does have one
-        if (_runtime_name.empty()) {
-            return !type->runtime_name().empty();
-        }
-        // Otherwise, the runtimes need to be the same
-        if (_runtime_name != type->runtime_name()) {
-            return false;
-        }
-        // Otherwise, the other one is a specialization if this does not have a type but the other one does
-        return _type_name.empty() && !type->type_name().empty();
-    }
-
-    bool runtime::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Runtime is a real type
-        return true;
+        return _runtime_name.empty() || (_runtime_name == runtime->runtime_name() && (_type_name.empty() || _type_name == runtime->type_name()));
     }
 
     void runtime::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/scalar.cc
+++ b/lib/src/runtime/types/scalar.cc
@@ -5,37 +5,26 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    scalar const scalar::instance{};
+
     char const* scalar::name()
     {
         return "Scalar";
     }
 
-    bool scalar::is_instance(values::value const& value) const
+    bool scalar::is_instance(values::value const& value, recursion_guard& guard) const
     {
-        // A Scalar is a Numeric, String, Boolean, and Regexp
-        return
-            numeric().is_instance(value) ||
-            string().is_instance(value) ||
-            boolean().is_instance(value) ||
-            regexp().is_instance(value);
+        return numeric::instance.is_instance(value, guard) || string::instance.is_instance(value, guard) ||
+               boolean::instance.is_instance(value, guard) || regexp::instance.is_instance(value, guard);
     }
 
-    bool scalar::is_specialization(values::type const& other) const
+    bool scalar::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Numeric, String, Boolean and Regexp are specializations
-        // Also specializations of Numeric and String
-        return boost::get<numeric>(&other) ||
-               boost::get<string>(&other) ||
-               boost::get<boolean>(&other) ||
-               boost::get<regexp>(&other) ||
-               numeric().is_specialization(other) ||
-               string().is_specialization(other);
-    }
-
-    bool scalar::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Scalar is a real type
-        return true;
+        if (boost::get<scalar>(&other)) {
+            return true;
+        }
+        return numeric::instance.is_assignable(other, guard) || string::instance.is_assignable(other, guard) ||
+               boolean::instance.is_assignable(other, guard) || regexp::instance.is_assignable(other, guard);
     }
 
     void scalar::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/string.cc
+++ b/lib/src/runtime/types/string.cc
@@ -105,7 +105,7 @@ namespace puppet { namespace runtime { namespace types {
 
     size_t hash_value(string const& type)
     {
-         static const size_t name_hash = boost::hash_value(string::name());
+        static const size_t name_hash = boost::hash_value(string::name());
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);

--- a/lib/src/runtime/types/struct.cc
+++ b/lib/src/runtime/types/struct.cc
@@ -218,7 +218,10 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        boost::hash_range(seed, type.schema().begin(), type.schema().end());
+        for (auto& kvp : type.schema()) {
+            boost::hash_combine(seed, *kvp.first);
+            boost::hash_combine(seed, *kvp.second);
+        }
         return seed;
     }
 

--- a/lib/src/runtime/types/tuple.cc
+++ b/lib/src/runtime/types/tuple.cc
@@ -6,6 +6,8 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    tuple const tuple::instance;
+
     tuple::tuple(vector<unique_ptr<values::type>> types, int64_t from, int64_t to) :
         _types(rvalue_cast(types)),
         _from(from),
@@ -59,7 +61,7 @@ namespace puppet { namespace runtime { namespace types {
         return "Tuple";
     }
 
-    bool tuple::is_instance(values::value const& value) const
+    bool tuple::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for array
         auto ptr = value.as<values::array>();
@@ -88,51 +90,52 @@ namespace puppet { namespace runtime { namespace types {
             // If this element's position is in the tuple, match the type
             // If not, match the last type
             if (i < _types.size()) {
-                if (!_types[i]->is_instance(*element)) {
+                if (!_types[i]->is_instance(*element, guard)) {
                     return false;
                 }
-            } else if (!last_type->is_instance(*element)) {
+            } else if (!last_type->is_instance(*element, guard)) {
                 return false;
             }
         }
         return true;
     }
 
-    bool tuple::is_specialization(values::type const& other) const
+    bool tuple::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // Check for another Tuple
-        auto ptr = boost::get<types::tuple>(&other);
-        if (!ptr) {
-            return false;
-        }
-
-        // Check for less types (i.e. this type is more specialized)
-        auto& other_types = ptr->types();
-        if (other_types.size() < _types.size()) {
-            return false;
-        }
-        // All types must match
-        for (size_t i = 0; i < _types.size(); ++i) {
-            if (_types[i] != other_types[i]) {
-                return false;
+        int64_t from, to;
+        if (auto array = boost::get<types::array>(&other)) {
+            if (!_types.empty()) {
+                auto count = std::min(static_cast<int64_t>(_types.size()), _to);
+                for (int64_t i = 0; i < count; ++i) {
+                    if (!_types[i]->is_assignable(array->element_type(), guard)) {
+                        return false;
+                    }
+                }
             }
-        }
-        // If the other type has more types, it is more specialized
-        if (other_types.size() > _types.size()) {
-            return true;
-        }
-        // Check for equality
-        if (ptr->from() == _from && ptr->to() == _to) {
+            from = array->from();
+            to = array->to();
+        } else if (auto tuple = boost::get<types::tuple>(&other)) {
+            if (!_types.empty()) {
+                auto& other_types = tuple->types();
+                auto& last_type = _types.back();
+                for (size_t i = 0; i < other_types.size(); ++i) {
+                    if (i < _types.size()) {
+                        if (!_types[i]->is_assignable(*other_types[i], guard)) {
+                            return false;
+                        }
+                    } else {
+                        if (!last_type->is_assignable(*other_types[i], guard)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            from = tuple->from();
+            to = tuple->to();
+        } else {
             return false;
         }
-        return std::min(ptr->from(), ptr->to()) >= std::min(_from, _to) &&
-               std::max(ptr->from(), ptr->to()) <= std::max(_from, _to);
-    }
-
-    bool tuple::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Tuple is a real type
-        return true;
+        return std::min(from, to) >= std::min(_from, _to) && std::max(from, to) <= std::max(_from, _to);
     }
 
     void tuple::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/tuple.cc
+++ b/lib/src/runtime/types/tuple.cc
@@ -211,7 +211,9 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        boost::hash_range(seed, type.types().begin(), type.types().end());
+        for (auto& t : type.types()) {
+            boost::hash_combine(seed, *t);
+        }
         boost::hash_combine(seed, type.from());
         boost::hash_combine(seed, type.to());
         return seed;

--- a/lib/src/runtime/types/undef.cc
+++ b/lib/src/runtime/types/undef.cc
@@ -5,26 +5,21 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    undef const undef::instance{};
+
     char const* undef::name()
     {
         return "Undef";
     }
 
-    bool undef::is_instance(values::value const& value) const
+    bool undef::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.is_undef();
     }
 
-    bool undef::is_specialization(values::type const& other) const
+    bool undef::is_assignable(values::type const& other, recursion_guard& guard) const
     {
-        // No specializations of Undef
-        return false;
-    }
-
-    bool undef::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // Undef is a real type
-        return true;
+        return boost::get<undef>(&other);
     }
 
     void undef::write(ostream& stream, bool expand) const

--- a/lib/src/runtime/types/variant.cc
+++ b/lib/src/runtime/types/variant.cc
@@ -158,7 +158,9 @@ namespace puppet { namespace runtime { namespace types {
 
         size_t seed = 0;
         boost::hash_combine(seed, name_hash);
-        boost::hash_range(seed, type.types().begin(), type.types().end());
+        for (auto& t : type.types()) {
+            boost::hash_combine(seed, *t);
+        }
         return seed;
     }
 

--- a/lib/src/runtime/types/variant.cc
+++ b/lib/src/runtime/types/variant.cc
@@ -43,59 +43,45 @@ namespace puppet { namespace runtime { namespace types {
         return "Variant";
     }
 
-    bool variant::is_instance(values::value const& value) const
+    bool variant::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Go through each type and ensure one matches
         for (auto const& type : _types) {
-            // Skip any self referencing aliases
-            if (is_self_referencing(*type)) {
-                continue;
-            }
-            if (type->is_instance(value)) {
+            if (type->is_instance(value, guard)) {
                 return true;
             }
         }
         return false;
     }
 
-    bool variant::is_specialization(values::type const& other) const
+    bool variant::is_assignable(values::type const& other, recursion_guard& guard) const
     {
         // Check for another Variant
         auto ptr = boost::get<variant>(&other);
-        if (!ptr) {
-            return false;
+        if (ptr) {
+            // A Variant with no types is assignable
+            for (auto& other_type : ptr->_types) {
+                bool found = false;
+                for (auto& type : _types) {
+                    found = type->is_assignable(*other_type, guard);
+                    if (found) {
+                        break;
+                    }
+                }
+                if (!found) {
+                    return false;
+                }
+            }
+            return true;
         }
 
-        // Check for less types (i.e. this type is more specialized)
-        auto& other_types = ptr->types();
-        if (other_types.size() < _types.size()) {
-            return false;
-        }
-        // All types must match
-        for (size_t i = 0; i < _types.size(); ++i) {
-            if (*_types[i] != *other_types[i]) {
-                return false;
+        // Check that the type is assignable to something in this Variant
+        for (auto& type : _types) {
+            if (type->is_assignable(other, guard)) {
+                return true;
             }
         }
-        // If the other type has more types, it is more specialized
-        return other_types.size() > _types.size();
-    }
-
-    bool variant::is_real(unordered_map<values::type const*, bool>& map) const
-    {
-        // A Variant is real provided all of its types are real
-        bool is_real = false;
-        for (auto const& element : _types) {
-            // Skip over any directly self-referential type aliases to allow an alias such as `type Foo = Variant[String, Foo]`.
-            if (is_self_referencing(*element)) {
-                continue;
-            }
-            is_real = element->is_real(map);
-            if (!is_real) {
-                return false;
-            }
-        }
-        return is_real;
+        return false;
     }
 
     void variant::write(ostream& stream, bool expand) const
@@ -115,11 +101,6 @@ namespace puppet { namespace runtime { namespace types {
             element->write(stream, false);
         }
         stream << ']';
-    }
-
-    bool variant::is_self_referencing(values::type const& type) const
-    {
-        return boost::get<variant>(&type) == this;
     }
 
     ostream& operator<<(ostream& os, variant const& type)

--- a/lib/src/runtime/values/hash.cc
+++ b/lib/src/runtime/values/hash.cc
@@ -163,9 +163,9 @@ namespace puppet { namespace runtime { namespace values {
         return hash_value(*value);
     }
 
-    bool hash::indirect_comparer::operator()(values::value const* right, values::value const* left) const
+    bool hash::indirect_comparer::operator()(values::value const* left, values::value const* right) const
     {
-        return *right == *left;
+        return *left == *right;
     }
 
     ostream& operator<<(ostream& os, values::hash const& hash)

--- a/lib/tests/fixtures/compiler/evaluation/type_comparisons.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/type_comparisons.baseline
@@ -1,0 +1,50 @@
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
+++ b/lib/tests/fixtures/compiler/evaluation/type_comparisons.pp
@@ -1,0 +1,2818 @@
+# Tests for alias
+
+type A = Array[String]
+
+unless A == Array[String] {
+    fail incorrect
+}
+
+unless Array > A {
+    fail incorrect
+}
+
+if A > Array[Integer] {
+    fail incorrect
+}
+
+unless Array >= A {
+    fail incorrect
+}
+
+if A >= Array[Integer] {
+    fail incorrect
+}
+
+if Array < A {
+    fail incorrect
+}
+
+if A < Array[Integer] {
+    fail incorrect
+}
+
+unless Array >= A {
+    fail incorrect
+}
+
+if A >= Array[Integer] {
+    fail incorrect
+}
+
+type X = Variant[X, Y, Z]
+type Y = Variant[X, String]
+type Z = Variant[Integer]
+
+unless X == X and X == Y {
+    fail incorrect
+}
+
+unless X >= X and X >= Y and X >= Z {
+    fail incorrect
+}
+
+unless X >= Variant[String, Integer] and X >= Variant[String] and X >= Variant[Integer] and X >= String and X >= Integer {
+    fail incorrect
+}
+
+if X >= Variant[Regexp] or X >= Regexp {
+    fail incorrect
+}
+
+# Tests for Any
+
+unless Any == Any {
+    fail incorrect
+}
+
+unless Any > String {
+    fail incorrect
+}
+
+if Any > Any {
+    fail incorrect
+}
+
+unless Any >= String {
+    fail incorrect
+}
+
+unless Any >= Any {
+    fail incorrect
+}
+
+if Any < String {
+    fail incorrect
+}
+
+if Any < Any {
+    fail incorrect
+}
+
+if Any <= String {
+    fail incorrect
+}
+
+unless Any <= Any {
+    fail incorrect
+}
+
+# Tests for Array
+
+unless Array == Array {
+    fail incorrect
+}
+
+unless Array[String] == Array[String] {
+    fail incorrect
+}
+
+unless Array[String, 5, 10] == Array[String, 5, 10] {
+    fail incorrect
+}
+
+if Array > String {
+    fail incorrect
+}
+
+if Array > Array {
+    fail incorrect
+}
+
+unless Array > Array[Integer] {
+    fail incorrect
+}
+
+unless Array[String] > Tuple[String, String, String] {
+    fail incorrect
+}
+
+if Array[String] > Array[Integer] {
+    fail incorrect
+}
+
+if Array[String] > Tuple[String, Integer] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] > Array[String, 0, 5] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] > Array[String, 1, 2] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] > Tuple[String, 1, 2] {
+    fail incorrect
+}
+
+if Array >= String {
+    fail incorrect
+}
+
+unless Array >= Array {
+    fail incorrect
+}
+
+unless Array >= Array[Integer] {
+    fail incorrect
+}
+
+unless Array[String] >= Tuple[String] {
+    fail incorrect
+}
+
+if Array[String] > Array[Integer] {
+    fail incorrect
+}
+
+if Array[String] >= Tuple[String, Integer] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] >= Array[String, 0, 5] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] >= Array[String, 1, 2] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] >= Tuple[String, 1, 2] {
+    fail incorrect
+}
+
+if Array < String {
+    fail incorrect
+}
+
+if Array < Array {
+    fail incorrect
+}
+
+if Array < Array[Integer] {
+    fail incorrect
+}
+
+if Array[String] < Tuple[String] {
+    fail incorrect
+}
+
+if Array[String] < Array[Integer] {
+    fail incorrect
+}
+
+if Array[String] < Tuple[String, Integer] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] < Array[String, 0, 5] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] < Array[String, 1, 2] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] < Tuple[String, 1, 2] {
+    fail incorrect
+}
+
+if Array <= String {
+    fail incorrect
+}
+
+unless Array <= Array {
+    fail incorrect
+}
+
+if Array <= Array[Integer] {
+    fail incorrect
+}
+
+if Array[String] <= Tuple[String] {
+    fail incorrect
+}
+
+if Array[String] <= Tuple[String] {
+    fail incorrect
+}
+
+if Array[String] <= Array[Integer] {
+    fail incorrect
+}
+
+unless Array[String, 0, 5] <= Array[String, 0, 5] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] <= Array[String, 1, 2] {
+    fail incorrect
+}
+
+if Array[String, 0, 5] <= Tuple[String, 1, 2] {
+    fail incorrect
+}
+
+# Boolean tests
+
+if Boolean > Integer {
+    fail incorrect
+}
+
+if Boolean > Boolean {
+    fail incorrect
+}
+
+if Boolean >= Integer {
+    fail incorrect
+}
+
+unless Boolean >= Boolean {
+    fail incorrect
+}
+
+if Boolean < Integer {
+    fail incorrect
+}
+
+if Boolean < Boolean {
+    fail incorrect
+}
+
+if Boolean <= Integer {
+    fail incorrect
+}
+
+unless Boolean <= Boolean {
+    fail incorrect
+}
+
+# Callable tests
+
+unless Callable == Callable and Callable[String] == Callable[String] and Callable[String, Integer, 0, 2, Callable[String]] == Callable[String, Integer, 0, 2, Callable[String]] {
+    fail incorrect
+}
+
+unless Callable > Callable[String] {
+    fail incorrect
+}
+
+unless Callable >= Callable[String] {
+    fail incorrect
+}
+
+if Callable < Callable[String] {
+    fail incorrect
+}
+
+if Callable <= Callable[String] {
+    fail incorrect
+}
+
+unless Callable[Integer] >= Callable[Numeric] {
+    fail incorrect
+}
+
+if Callable[Integer, 0, 2, Callable[Integer]] >= Callable[Numeric, 0, 2, Callable[Numeric]] {
+    fail incorrect
+}
+
+unless Callable[Integer] > Callable[Numeric] {
+    fail incorrect
+}
+
+if Callable[Integer, 0, 2, Callable[Integer]] > Callable[Numeric, 0, 2, Callable[Numeric]] {
+    fail incorrect
+}
+
+if Callable[Integer] <= Callable[Numeric] {
+    fail incorrect
+}
+
+if Callable[Integer] < Callable[Numeric] {
+    fail incorrect
+}
+
+if Callable[Integer, 0, 2, Callable[Integer]] < Callable[Numeric, 0, 2, Callable[Numeric]] {
+    fail incorrect
+}
+
+if Callable[Integer] <= Callable[Numeric] {
+    fail incorrect
+}
+
+if Callable[Integer, 0, 2, Callable[Integer]] <= Callable[Numeric, 0, 2, Callable[Numeric]] {
+    fail incorrect
+}
+
+# CatalogEntry tests
+
+unless CatalogEntry == CatalogEntry {
+    fail incorrect
+}
+
+unless CatalogEntry > Resource and CatalogEntry > Class {
+    fail incorrect
+}
+
+unless CatalogEntry >= Resource and CatalogEntry >= Class {
+    fail incorrect
+}
+
+if CatalogEntry < Resource or CatalogEntry < Class {
+    fail incorrect
+}
+
+if CatalogEntry <= Resource or CatalogEntry <= Class {
+    fail incorrect
+}
+
+# Class tests
+
+unless Class == Class and Class[foo] == Class[foo] and Class[foo] != Class[bar] {
+    fail incorrect
+}
+
+unless Class > Class[foo] {
+    fail incorrect
+}
+
+if Class > Class or Class[foo] > Class[foo] {
+    fail incorrect
+}
+
+unless Class >= Class[foo] and Class[foo] >= Class[foo] {
+    fail incorrect
+}
+
+if Class[foo] >= Class[bar] {
+    fail incorrect
+}
+
+if Class < Class[foo] {
+    fail incorrect
+}
+
+if Class < Class or Class[foo] < Class[foo] {
+    fail incorrect
+}
+
+if Class <= Class[foo] {
+    fail incorrect
+}
+
+unless Class[foo] <= Class[foo] {
+    fail incorrect
+}
+
+if Class[foo] <= Class[bar] {
+    fail incorrect
+}
+
+# Collection tests
+
+unless Collection == Collection and Collection[5] == Collection[5] and Collection[5] != Collection[10] and Collection[10, 100] == Collection[10, 100] and Collection[10, 100] != Collection[20, 200] {
+    fail incorrect
+}
+
+unless Collection > Array and Collection > Tuple and Collection > Hash {
+    fail incorrect
+}
+
+if Collection > Collection {
+    fail incorrect
+}
+
+if Collection > String {
+    fail incorrect
+}
+
+unless Collection[0, 10] > Array[String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] > Array[String, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] > Tuple[Integer, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] > Tuple[Integer, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] > Hash[String, String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] > Hash[String, String, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] > Collection[0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] > Collection[0, 10] {
+    fail incorrect
+}
+
+if Collection >= String {
+    fail incorrect
+}
+
+unless Collection[0, 10] >= Array[String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] >= Array[String, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] >= Tuple[Integer, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] >= Tuple[Integer, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] >= Hash[String, String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] >= Hash[String, String, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] >= Collection[0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] >= Collection[0, 10] {
+    fail incorrect
+}
+
+if Collection < String {
+    fail incorrect
+}
+
+if Collection[0, 10] < Array[String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] < Array[String, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] < Tuple[Integer, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] < Tuple[Integer, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] < Hash[String, String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] < Hash[String, String, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] < Collection[0, 10] {
+    fail incorrect
+}
+
+unless Collection[5, 5] < Collection[0, 10] {
+    fail incorrect
+}
+
+if Collection <= String {
+    fail incorrect
+}
+
+if Collection[0, 10] <= Array[String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] <= Array[String, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] <=Tuple[Integer, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] <= Tuple[Integer, default, 10] {
+    fail incorrect
+}
+
+if Collection[0, 10] <= Hash[String, String, 0, 10] {
+    fail incorrect
+}
+
+if Collection[5, 5] <= Hash[String, String, default, 10] {
+    fail incorrect
+}
+
+unless Collection[0, 10] <= Collection[0, 10] {
+    fail incorrect
+}
+
+unless Collection[5, 5] <= Collection[0, 10] {
+    fail incorrect
+}
+
+# Data tests
+
+unless Data == Data {
+    fail incorrect
+}
+
+unless Data > Scalar and Data > Array and Data > Hash and Data > Undef and Data > Tuple {
+    fail incorrect
+}
+
+if Data > Data {
+    fail incorrect
+}
+
+if Data > Type {
+    fail incorrect
+}
+
+unless Data >= Scalar and Data >= Array and Data >= Hash and Data >= Undef and Data >= Tuple {
+    fail incorrect
+}
+
+unless Data >= Data {
+    fail incorrect
+}
+
+if Data >= Type {
+    fail incorrect
+}
+
+if Data < Scalar or Data < Array or Data < Hash or Data < Undef or Data < Tuple {
+    fail incorrect
+}
+
+if Data < Data {
+    fail incorrect
+}
+
+if Data < Type {
+    fail incorrect
+}
+
+if Data <= Scalar or Data <= Array or Data <= Hash or Data <= Undef or Data <= Tuple {
+    fail incorrect
+}
+
+unless Data <= Data {
+    fail incorrect
+}
+
+if Data <= Type {
+    fail incorrect
+}
+
+# Default tests
+
+unless Default == Default {
+    fail incorrect
+}
+
+if Default > Default {
+    fail incorrect
+}
+
+if Default > String {
+    fail incorrect
+}
+
+unless Default >= Default {
+    fail incorrect
+}
+
+if Default > String {
+    fail incorrect
+}
+
+if Default < Default {
+    fail incorrect
+}
+
+if Default < String {
+    fail incorrect
+}
+
+unless Default <= Default {
+    fail incorrect
+}
+
+if Default <= String {
+    fail incorrect
+}
+
+# Enum tests
+
+unless Enum == Enum {
+    fail incorrect
+}
+
+if Enum > Integer or Enum[foo] > String or Enum[foo] > Enum or Enum[foo] > Pattern {
+    fail incorrect
+}
+
+if Enum > String or Enum > Pattern {
+    fail incorrect
+}
+
+unless Enum > Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo] > Enum[foo] {
+    fail incorrect
+}
+
+unless Enum[foo, bar] > Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] > Enum[foo, baz] {
+    fail incorrect
+}
+
+if Enum >= Integer or Enum[foo] >= String or Enum[foo] >= Enum or Enum[foo] >= Pattern {
+    fail incorrect
+}
+
+unless Enum >= String and Enum >= Pattern {
+    fail incorrect
+}
+
+unless Enum >= Enum[foo] {
+    fail incorrect
+}
+
+unless Enum[foo] >= Enum[foo] {
+    fail incorrect
+}
+
+unless Enum[foo, bar] >= Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] >= Enum[foo, baz] {
+    fail incorrect
+}
+
+if Enum < Integer {
+    fail incorrect
+}
+
+unless Enum[foo] < String and Enum[foo] < Enum and Enum[foo] < Pattern {
+    fail incorrect
+}
+
+if Enum < String or Enum < Pattern {
+    fail incorrect
+}
+
+if Enum < Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo] < Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] < Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] < Enum[foo, baz] {
+    fail incorrect
+}
+
+if Enum <= Integer {
+    fail incorrect
+}
+
+unless Enum[foo] <= String and Enum[foo] <= Enum and Enum[foo] <= Pattern {
+    fail incorrect
+}
+
+unless Enum <= String and Enum <= Pattern {
+    fail incorrect
+}
+
+if Enum <= Enum[foo] {
+    fail incorrect
+}
+
+unless Enum[foo] <= Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] <= Enum[foo] {
+    fail incorrect
+}
+
+if Enum[foo, bar] <= Enum[foo, baz] {
+    fail incorrect
+}
+
+# Float tests
+
+unless Float == Float and Float[3] == Float[3] and Float[0, 100] == Float[0, 100] {
+    fail incorrect
+}
+
+if Float > Float {
+    fail incorrect
+}
+
+unless Float > Float[3] and Float > Float[0, 100] {
+    fail incorrect
+}
+
+unless Float[0, 10] > Float[5, 5] {
+    fail incorrect
+}
+
+if Float[5, 5] > Float[0, 10] {
+    fail incorrect
+}
+
+unless Float >= Float {
+    fail incorrect
+}
+
+unless Float >= Float[3] and Float >= Float[0, 100] {
+    fail incorrect
+}
+
+unless Float[0, 10] >= Float[5, 5] {
+    fail incorrect
+}
+
+if Float[5, 5] >= Float[0, 10] {
+    fail incorrect
+}
+
+if Float < Float {
+    fail incorrect
+}
+
+if Float < Float[3] or Float < Float[0, 100] {
+    fail incorrect
+}
+
+if Float[0, 10] < Float[5, 5] {
+    fail incorrect
+}
+
+unless Float[5, 5] < Float[0, 10] {
+    fail incorrect
+}
+
+unless Float <= Float {
+    fail incorrect
+}
+
+if Float <= Float[3] or Float <= Float[0, 100] {
+    fail incorrect
+}
+
+if Float[0, 10] <= Float[5, 5] {
+    fail incorrect
+}
+
+unless Float[5, 5] <= Float[0, 10] {
+    fail incorrect
+}
+
+# Hash tests
+
+unless Hash == Hash and Hash[String, Integer] == Hash[String, Integer] and
+       Hash[String, Integer, 0] == Hash[String, Integer, 0] and Hash[String, Integer, 0, 10] == Hash[String, Integer, 0, 10] {
+    fail incorrect
+}
+
+unless Hash[String, Integer] != Hash[String, String] and Hash[String, Integer, 0] != Hash[String, Integer, 10] and Hash[String, Integer, 0, 10] != Hash[String, Integer, 0, 20] {
+    fail incorrect
+}
+
+if Hash > Hash {
+    fail incorrect
+}
+
+if Hash > String {
+    fail incorrect
+}
+
+unless Hash > Hash[String, String] {
+    fail incorrect
+}
+
+unless Hash[Numeric, Numeric] > Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] > Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] > Hash[String, String] {
+    fail incorrect
+}
+
+unless Hash[Numeric, String, 0, 10] > Hash[Integer, String, 5, 5] {
+    fail incorrect
+}
+
+if Hash[Numeric, String, 5, 5] > Hash[Integer, String, 0, 10] {
+    fail incorrect
+}
+
+unless Hash[String, String] > Struct[{ foo => String, bar => String }] {
+    fail incorrectqqq
+}
+
+if Hash[Integer, String] > Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, Integer] > Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, String, 2, 2] > Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+unless Hash[String, String] > Struct[{ Optional[foo] => String, NotUndef[bar] => String }] {
+    fail incorrect
+}
+
+unless Hash >= Hash {
+    fail incorrect
+}
+
+if Hash >= String {
+    fail incorrect
+}
+
+unless Hash >= Hash[String, String] {
+    fail incorrect
+}
+
+unless Hash[Numeric, Numeric] >= Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] >= Hash[Integer, Integer] {
+    fail incorrect
+}
+
+unless Hash[String, String] >= Hash[String, String] {
+    fail incorrect
+}
+
+unless Hash[Numeric, String, 0, 10] >= Hash[Integer, String, 5, 5] {
+    fail incorrect
+}
+
+if Hash[Numeric, String, 5, 5] >= Hash[Integer, String, 0, 10] {
+    fail incorrect
+}
+
+unless Hash[String, String] >= Struct[{ foo => String, bar => String }] {
+    fail incorrectqqq
+}
+
+if Hash[Integer, String] >= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, Integer] >= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+unless Hash[String, String, 2, 2] >= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+unless Hash[String, String] >= Struct[{ Optional[foo] => String, NotUndef[bar] => String }] {
+    fail incorrect
+}
+
+if Hash < Hash {
+    fail incorrect
+}
+
+if Hash < String {
+    fail incorrect
+}
+
+if Hash < Hash[String, String] {
+    fail incorrect
+}
+
+if Hash[Numeric, Numeric] < Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] < Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] < Hash[String, String] {
+    fail incorrect
+}
+
+if Hash[Numeric, String, 0, 10] < Hash[Integer, String, 5, 5] {
+    fail incorrect
+}
+
+unless Hash[Integer, String, 5, 5] < Hash[Numeric, String, 0, 10] {
+    fail incorrect
+}
+
+if Hash[String, String] < Struct[{ foo => String, bar => String }] {
+    fail incorrectqqq
+}
+
+if Hash[Integer, String] < Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, Integer] < Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, String, 2, 2] < Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, String] < Struct[{ Optional[foo] => String, NotUndef[bar] => String }] {
+    fail incorrect
+}
+
+unless Hash <= Hash {
+    fail incorrect
+}
+
+if Hash <= String {
+    fail incorrect
+}
+
+if Hash <= Hash[String, String] {
+    fail incorrect
+}
+
+if Hash[Numeric, Numeric] <= Hash[Integer, Integer] {
+    fail incorrect
+}
+
+if Hash[String, String] <= Hash[Integer, Integer] {
+    fail incorrect
+}
+
+unless Hash[String, String] <= Hash[String, String] {
+    fail incorrect
+}
+
+if Hash[Numeric, String, 0, 10] <= Hash[Integer, String, 5, 5] {
+    fail incorrect
+}
+
+unless Hash[Integer, String, 5, 5] <= Hash[Numeric, String, 0, 10] {
+    fail incorrect
+}
+
+if Hash[String, String] <= Struct[{ foo => String, bar => String }] {
+    fail incorrectqqq
+}
+
+if Hash[Integer, String] <= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, Integer] <= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+unless Hash[String, String, 2, 2] <= Struct[{ foo => String, bar => String }] {
+    fail incorrect
+}
+
+if Hash[String, String] <= Struct[{ Optional[foo] => String, NotUndef[bar] => String }] {
+    fail incorrect
+}
+
+# Integer tests
+
+unless Integer == Integer and Integer[3] == Integer[3] and Integer[0, 100] == Integer[0, 100] {
+    fail incorrect
+}
+
+if Integer > Integer {
+    fail incorrect
+}
+
+unless Integer > Integer[3] and Integer > Integer[0, 100] {
+    fail incorrect
+}
+
+unless Integer[0, 10] > Integer[5, 5] {
+    fail incorrect
+}
+
+if Integer[5, 5] > Integer[0, 10] {
+    fail incorrect
+}
+
+unless Integer >= Integer {
+    fail incorrect
+}
+
+unless Integer >= Integer[3] and Integer >= Integer[0, 100] {
+    fail incorrect
+}
+
+unless Integer[0, 10] >= Integer[5, 5] {
+    fail incorrect
+}
+
+if Integer[5, 5] >= Integer[0, 10] {
+    fail incorrect
+}
+
+if Integer < Integer {
+    fail incorrect
+}
+
+if Integer < Integer[3] or Integer < Integer[0, 100] {
+    fail incorrect
+}
+
+if Integer[0, 10] < Integer[5, 5] {
+    fail incorrect
+}
+
+unless Integer[5, 5] < Integer[0, 10] {
+    fail incorrect
+}
+
+unless Integer <= Integer {
+    fail incorrect
+}
+
+if Integer <= Integer[3] or Integer <= Integer[0, 100] {
+    fail incorrect
+}
+
+if Integer[0, 10] <= Integer[5, 5] {
+    fail incorrect
+}
+
+unless Integer[5, 5] <= Integer[0, 10] {
+    fail incorrect
+}
+
+unless Iterable == Iterable and Iterable[String] == Iterable[String] {
+    fail incorrect
+}
+
+unless Iterable != Iterable[String] and Iterable[String] != Iterable[Integer] {
+    fail incorrect
+}
+
+if Iterable > Iterable or Iterable[String] > Iterable[String] {
+    fail incorrect
+}
+
+if Iterable > Float {
+    fail incorrect
+}
+
+unless Iterable > String and Iterable[String] > String {
+    fail incorrect
+}
+
+unless Iterable > Array {
+    fail incorrect
+}
+
+if Iterable[Integer] > Array or Iterable[Integer] > Array[String] {
+    fail incorrect
+}
+
+unless Iterable[String] > Array[String] {
+    fail incorrect
+}
+
+unless Iterable > Hash and Iterable[Tuple[String, Integer]] > Hash[String, Integer] {
+    fail incorrect
+}
+
+if Iterable[String] > Hash or Iterable[Tuple[String]] > Hash[String, String] or Iterable[Tuple[String, Integer]] > Hash[Integer, String] {
+    fail incorrect
+}
+
+if Iterable > Integer or Iterable > Integer[0, default] or Iterable > Integer[default, 10] {
+    fail incorrect
+}
+
+unless Iterable > Integer[0, 10] and Iterable[Integer] > Integer[0, 10] {
+    fail incorrect
+}
+
+if Iterable[String] > Integer[0, 10] or Iterable[Integer[0, 10]] > Integer[20, 30] {
+    fail incorrect
+}
+
+unless Iterable > Enum {
+    fail incorrect
+}
+
+unless Iterable[String] > Enum[foo] {
+    fail incorrect
+}
+
+if Iterable[Integer] > Enum[foo] {
+    fail incorrect
+}
+
+# TODO: add tests for Iterable compared to Iterator
+
+# TODO: add Iterator tests
+
+# Numeric tests
+
+unless Numeric == Numeric {
+    fail incorrect
+}
+
+if Numeric > Numeric {
+    fail incorrect
+}
+
+unless Numeric > Integer and Numeric > Integer[0, 10] and Numeric > Float and Numeric > Float[0, 10] {
+    fail incorrect
+}
+
+if Numeric > String {
+    fail incorrect
+}
+
+unless Numeric >= Numeric {
+    fail incorrect
+}
+
+unless Numeric >= Integer and Numeric >= Integer[0, 10] and Numeric >= Float and Numeric >= Float[0, 10] {
+    fail incorrect
+}
+
+if Numeric >= String {
+    fail incorrect
+}
+
+if Numeric < Numeric {
+    fail incorrect
+}
+
+if Numeric < Integer or Numeric < Integer[0, 10] or Numeric < Float or Numeric < Float[0, 10] {
+    fail incorrect
+}
+
+if Numeric < String {
+    fail incorrect
+}
+
+unless Numeric <= Numeric {
+    fail incorrect
+}
+
+if Numeric <= Integer or Numeric <= Integer[0, 10] or Numeric <= Float or Numeric <= Float[0, 10] {
+    fail incorrect
+}
+
+if Numeric <= String {
+    fail incorrect
+}
+
+# Optional tests
+
+unless Optional == Optional and Optional[String] == Optional[String] and Optional == Optional[Undef] {
+    fail incorrect
+}
+
+unless Optional[Integer] != Optional[String] {
+    fail incorrect
+}
+
+unless Optional > Undef and Optional[String] > Undef {
+    fail incorrect
+}
+
+if Optional > Optional or Optional[String] > Optional[String] {
+    fail incorrect
+}
+
+unless Optional > Undef {
+    fail incorrect
+}
+
+if Optional > Optional[String] {
+    fail incorrect
+}
+
+unless Optional[String] > String {
+    fail incorrect
+}
+
+unless Optional >= Undef and Optional[String] >= Undef {
+    fail incorrect
+}
+
+unless Optional >= Optional and Optional[String] >= Optional[String] {
+    fail incorrect
+}
+
+unless Optional >= Undef {
+    fail incorrect
+}
+
+if Optional >= Optional[String] {
+    fail incorrect
+}
+
+unless Optional[String] >= String {
+    fail incorrect
+}
+
+if Optional < Undef or Optional[String] < Undef {
+    fail incorrect
+}
+
+if Optional < Optional or Optional[String] < Optional[String] {
+    fail incorrect
+}
+
+if Optional < Undef {
+    fail incorrect
+}
+
+if Optional < Optional[String] {
+    fail incorrect
+}
+
+if Optional[String] < String {
+    fail incorrect
+}
+
+if Optional <= Undef or Optional[String] <= Undef {
+    fail incorrect
+}
+
+unless Optional <= Optional and Optional[String] <= Optional[String] {
+    fail incorrect
+}
+
+if Optional <= Undef {
+    fail incorrect
+}
+
+if Optional <= Optional[String] {
+    fail incorrect
+}
+
+if Optional[String] <= String {
+    fail incorrect
+}
+
+# Pattern tests
+
+unless Pattern == Pattern and Pattern[foo] == Pattern[foo] and Pattern[foo, /bar/] == Pattern[foo, /bar/] {
+    fail incorrect
+}
+
+if Pattern > Pattern {
+    fail incorrect
+}
+
+if Pattern[foo] > Pattern {
+    fail incorrect
+}
+
+if Pattern > String {
+    fail incorrect
+}
+
+if Pattern[foo] > String {
+    fail incorrect
+}
+
+if Pattern > Enum {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] > Enum {
+    fail incorrect
+}
+
+unless Pattern[/^foo$/] > Enum[foo] {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] > Enum[bar] {
+    fail incorrect
+}
+
+unless Pattern >= Pattern {
+    fail incorrect
+}
+
+if Pattern[foo] >= Pattern {
+    fail incorrect
+}
+
+unless Pattern >= String {
+    fail incorrect
+}
+
+if Pattern[foo] >= String {
+    fail incorrect
+}
+
+unless Pattern >= Enum {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] >= Enum {
+    fail incorrect
+}
+
+unless Pattern[/^foo$/] >= Enum[foo] {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] >= Enum[bar] {
+    fail incorrect
+}
+
+if Pattern < Pattern {
+    fail incorrect
+}
+
+unless Pattern[foo] < Pattern {
+    fail incorrect
+}
+
+if Pattern < String {
+    fail incorrect
+}
+
+unless Pattern[foo] < String {
+    fail incorrect
+}
+
+if Pattern < Enum {
+    fail incorrect
+}
+
+unless Pattern[/^foo$/] < Enum {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] < Enum[foo] {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] < Enum[bar] {
+    fail incorrect
+}
+
+unless Pattern <= Pattern {
+    fail incorrect
+}
+
+unless Pattern[foo] <= Pattern {
+    fail incorrect
+}
+
+unless Pattern <= String {
+    fail incorrect
+}
+
+unless Pattern[foo] <= String {
+    fail incorrect
+}
+
+unless Pattern <= Enum {
+    fail incorrect
+}
+
+unless Pattern[/^foo$/] <= Enum {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] <= Enum[foo] {
+    fail incorrect
+}
+
+if Pattern[/^foo$/] <= Enum[bar] {
+    fail incorrect
+}
+
+# Regexp tests
+
+unless Regexp == Regexp and Regexp[foo] == Regexp[/foo/] and Regexp[foo] != Regexp[bar] {
+    fail incorrect
+}
+
+if Regexp > String {
+    fail incorrect
+}
+
+if Regexp > Regexp {
+    fail incorrect
+}
+
+unless Regexp > Regexp[foo] {
+    fail incorrect
+}
+
+if Regexp[foo] > Regexp[/foo/] {
+    fail incorrect
+}
+
+if Regexp[/foo/] > Regexp[bar] {
+    fail incorrect
+}
+
+if Regexp >= String {
+    fail incorrect
+}
+
+unless Regexp >= Regexp {
+    fail incorrect
+}
+
+unless Regexp >= Regexp[foo] {
+    fail incorrect
+}
+
+unless Regexp[foo] >= Regexp[/foo/] {
+    fail incorrect
+}
+
+if Regexp[/foo/] >= Regexp[bar] {
+    fail incorrect
+}
+
+if Regexp < String {
+    fail incorrect
+}
+
+if Regexp < Regexp {
+    fail incorrect
+}
+
+if Regexp < Regexp[foo] {
+    fail incorrect
+}
+
+if Regexp[foo] < Regexp[/foo/] {
+    fail incorrect
+}
+
+if Regexp[/foo/] < Regexp[bar] {
+    fail incorrect
+}
+
+if Regexp <= String {
+    fail incorrect
+}
+
+unless Regexp <= Regexp {
+    fail incorrect
+}
+
+if Regexp <= Regexp[foo] {
+    fail incorrect
+}
+
+unless Regexp[foo] <= Regexp[/foo/] {
+    fail incorrect
+}
+
+if Regexp[/foo/] <= Regexp[bar] {
+    fail incorrect
+}
+
+# Resource tests
+
+unless Resource == Resource and Resource[foo] == Resource[foo] and Resource[foo] != Resource[bar] and Resource[foo, bar] == Resource[foo, bar] and Resource[foo, bar] != Resource[bar, foo] {
+    fail incorrect
+}
+
+if Resource > String {
+    fail incorrect
+}
+
+if Resource > Resource {
+    fail incorrect
+}
+
+unless Resource > Resource[foo] {
+    fail incorrect
+}
+
+unless Resource > Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] > Resource[foo] {
+    fail incorrect
+}
+
+if Resource[foo] > Resource[bar] {
+    fail incorrect
+}
+
+unless Resource[foo] > Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] > Resource[bar, baz] {
+    fail incorrect
+}
+
+if Resource[foo, bar] > Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo, bar] > Resource[foo, baz] {
+    fail incorrect
+}
+
+if Resource >= String {
+    fail incorrect
+}
+
+unless Resource >= Resource {
+    fail incorrect
+}
+
+unless Resource >= Resource[foo] {
+    fail incorrect
+}
+
+unless Resource >= Resource[foo, bar] {
+    fail incorrect
+}
+
+unless Resource[foo] >= Resource[foo] {
+    fail incorrect
+}
+
+if Resource[foo] >= Resource[bar] {
+    fail incorrect
+}
+
+unless Resource[foo] >= Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] >= Resource[bar, baz] {
+    fail incorrect
+}
+
+unless Resource[foo, bar] >= Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo, bar] >= Resource[foo, baz] {
+    fail incorrect
+}
+
+if Resource < String {
+    fail incorrect
+}
+
+if Resource < Resource {
+    fail incorrect
+}
+
+if Resource < Resource[foo] {
+    fail incorrect
+}
+
+if Resource < Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] < Resource[foo] {
+    fail incorrect
+}
+
+if Resource[foo] < Resource[bar] {
+    fail incorrect
+}
+
+if Resource[foo] < Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] < Resource[bar, baz] {
+    fail incorrect
+}
+
+if Resource[foo, bar] < Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo, bar] < Resource[foo, baz] {
+    fail incorrect
+}
+
+if Resource <= String {
+    fail incorrect
+}
+
+unless Resource <= Resource {
+    fail incorrect
+}
+
+if Resource <= Resource[foo] {
+    fail incorrect
+}
+
+if Resource <= Resource[foo, bar] {
+    fail incorrect
+}
+
+unless Resource[foo] <= Resource[foo] {
+    fail incorrect
+}
+
+if Resource[foo] <= Resource[bar] {
+    fail incorrect
+}
+
+if Resource[foo] <= Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo] <= Resource[bar, baz] {
+    fail incorrect
+}
+
+unless Resource[foo, bar] <= Resource[foo, bar] {
+    fail incorrect
+}
+
+if Resource[foo, bar] <= Resource[foo, baz] {
+    fail incorrect
+}
+
+# Runtime tests
+
+unless Runtime == Runtime and Runtime[foo] == Runtime[foo] and Runtime[foo] != Runtime[bar] and Runtime[foo, bar] == Runtime[foo, bar] and Runtime[foo, bar] != Runtime[bar, foo] {
+    fail incorrect
+}
+
+if Runtime > String {
+    fail incorrect
+}
+
+if Runtime > Runtime {
+    fail incorrect
+}
+
+unless Runtime > Runtime[foo] {
+    fail incorrect
+}
+
+unless Runtime > Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] > Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime[foo] > Runtime[bar] {
+    fail incorrect
+}
+
+unless Runtime[foo] > Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] > Runtime[bar, baz] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] > Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] > Runtime[foo, baz] {
+    fail incorrect
+}
+
+if Runtime >= String {
+    fail incorrect
+}
+
+unless Runtime >= Runtime {
+    fail incorrect
+}
+
+unless Runtime >= Runtime[foo] {
+    fail incorrect
+}
+
+unless Runtime >= Runtime[foo, bar] {
+    fail incorrect
+}
+
+unless Runtime[foo] >= Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime[foo] >= Runtime[bar] {
+    fail incorrect
+}
+
+unless Runtime[foo] >= Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] >= Runtime[bar, baz] {
+    fail incorrect
+}
+
+unless Runtime[foo, bar] >= Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] >= Runtime[foo, baz] {
+    fail incorrect
+}
+
+if Runtime < String {
+    fail incorrect
+}
+
+if Runtime < Runtime {
+    fail incorrect
+}
+
+if Runtime < Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime < Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] < Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime[foo] < Runtime[bar] {
+    fail incorrect
+}
+
+if Runtime[foo] < Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] < Runtime[bar, baz] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] < Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] < Runtime[foo, baz] {
+    fail incorrect
+}
+
+if Runtime <= String {
+    fail incorrect
+}
+
+unless Runtime <= Runtime {
+    fail incorrect
+}
+
+if Runtime <= Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime <= Runtime[foo, bar] {
+    fail incorrect
+}
+
+unless Runtime[foo] <= Runtime[foo] {
+    fail incorrect
+}
+
+if Runtime[foo] <= Runtime[bar] {
+    fail incorrect
+}
+
+if Runtime[foo] <= Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo] <= Runtime[bar, baz] {
+    fail incorrect
+}
+
+unless Runtime[foo, bar] <= Runtime[foo, bar] {
+    fail incorrect
+}
+
+if Runtime[foo, bar] <= Runtime[foo, baz] {
+    fail incorrect
+}
+
+# Scalar tests
+
+unless Scalar == Scalar {
+    fail incorrect
+}
+
+if Scalar > Scalar {
+    fail incorrect
+}
+
+if Scalar > Array {
+    fail incorrect
+}
+
+unless Scalar > Numeric {
+    fail incorrect
+}
+
+unless Scalar > Integer and Scalar > Integer[0, 10] {
+    fail incorrect
+}
+
+unless Scalar > Float and Scalar > Float[0, 10] {
+    fail incorrect
+}
+
+unless Scalar > String and Scalar > String[0, 10] {
+    fail incorrect
+}
+
+unless Scalar > Boolean {
+    fail incorrect
+}
+
+unless Scalar > Regexp and Scalar > Regexp[foo] {
+    fail incorrect
+}
+
+unless Scalar >= Scalar {
+    fail incorrect
+}
+
+if Scalar >= Array {
+    fail incorrect
+}
+
+unless Scalar >= Numeric {
+    fail incorrect
+}
+
+unless Scalar >= Integer and Scalar >= Integer[0, 10] {
+    fail incorrect
+}
+
+unless Scalar >= Float and Scalar >= Float[0, 10] {
+    fail incorrect
+}
+
+unless Scalar >= String and Scalar >= String[0, 10] {
+    fail incorrect
+}
+
+unless Scalar >= Boolean {
+    fail incorrect
+}
+
+unless Scalar >= Regexp and Scalar >= Regexp[foo] {
+    fail incorrect
+}
+
+if Scalar < Scalar {
+    fail incorrect
+}
+
+if Scalar < Array {
+    fail incorrect
+}
+
+if Scalar < Numeric {
+    fail incorrect
+}
+
+if Scalar < Integer or Scalar < Integer[0, 10] {
+    fail incorrect
+}
+
+if Scalar < Float or Scalar < Float[0, 10] {
+    fail incorrect
+}
+
+if Scalar < String or Scalar < String[0, 10] {
+    fail incorrect
+}
+
+if Scalar < Boolean {
+    fail incorrect
+}
+
+if Scalar < Regexp or Scalar < Regexp[foo] {
+    fail incorrect
+}
+
+unless Scalar <= Scalar {
+    fail incorrect
+}
+
+if Scalar <= Array {
+    fail incorrect
+}
+
+if Scalar <= Numeric {
+    fail incorrect
+}
+
+if Scalar <= Integer or Scalar <= Integer[0, 10] {
+    fail incorrect
+}
+
+if Scalar <= Float or Scalar <= Float[0, 10] {
+    fail incorrect
+}
+
+if Scalar <= String or Scalar <= String[0, 10] {
+    fail incorrect
+}
+
+if Scalar <= Boolean {
+    fail incorrect
+}
+
+if Scalar <= Regexp or Scalar <= Regexp[foo] {
+    fail incorrect
+}
+
+# String tests
+
+unless String == String and String[0] == String[0] and String[0] != String[10] and String[0, 10] == String[0, 10] and String[0, 10] != String[1, 2] {
+    fail incorrect
+}
+
+if String > Integer {
+    fail incorrect
+}
+
+if String > String {
+    fail incorrect
+}
+
+if String > String[0] {
+    fail incorrect
+}
+
+unless String[0] > String[1] {
+    fail incorrect
+}
+
+if String[5] > String[3] {
+    fail incorrect
+}
+
+unless String > String[0, 10] {
+    fail incorrect
+}
+
+unless String[0] > String[0, 10] {
+    fail incorrect
+}
+
+unless String[0, 10] > String[5, 6] {
+    fail incorrect
+}
+
+if String[0, 10] > String[20, 30] {
+    fail incorrect
+}
+
+if String >= Integer {
+    fail incorrect
+}
+
+unless String >= String {
+    fail incorrect
+}
+
+unless String >= String[0] {
+    fail incorrect
+}
+
+unless String[0] >= String[1] {
+    fail incorrect
+}
+
+if String[5] >= String[3] {
+    fail incorrect
+}
+
+unless String >= String[0, 10] {
+    fail incorrect
+}
+
+unless String[0] >= String[0, 10] {
+    fail incorrect
+}
+
+unless String[0, 10] >= String[5, 6] {
+    fail incorrect
+}
+
+if String[0, 10] >= String[20, 30] {
+    fail incorrect
+}
+
+if String < Integer {
+    fail incorrect
+}
+
+if String < String {
+    fail incorrect
+}
+
+if String < String[0] {
+    fail incorrect
+}
+
+if String[0] < String[1] {
+    fail incorrect
+}
+
+unless String[5] < String[3] {
+    fail incorrect
+}
+
+if String < String[0, 10] {
+    fail incorrect
+}
+
+if String[0] < String[0, 10] {
+    fail incorrect
+}
+
+if String[0, 10] < String[5, 6] {
+    fail incorrect
+}
+
+if String[0, 10] < String[20, 30] {
+    fail incorrect
+}
+
+if String <= Integer {
+    fail incorrect
+}
+
+unless String <= String {
+    fail incorrect
+}
+
+unless String <= String[0] {
+    fail incorrect
+}
+
+if String[0] <= String[1] {
+    fail incorrect
+}
+
+unless String[5] <= String[3] {
+    fail incorrect
+}
+
+if String <= String[0, 10] {
+    fail incorrect
+}
+
+if String[0] <= String[0, 10] {
+    fail incorrect
+}
+
+if String[0, 10] <= String[5, 6] {
+    fail incorrect
+}
+
+if String[0, 10] <= String[20, 30] {
+    fail incorrect
+}
+
+# Struct tests
+
+unless Struct == Struct and Struct[{foo => String, bar => String }] == Struct[{bar => String, foo => String}] {
+    fail incorrect
+}
+
+if Struct > Integer {
+    fail incorrect
+}
+
+if Struct > Struct {
+    fail incorrect
+}
+
+if Struct > Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+unless Struct[{ foo => Numeric }] > Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Integer }] > Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+unless Struct[{ Optional[foo] => Integer, bar => Integer }] > Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => Integer, bar => Integer }] > Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct > Hash {
+    fail incorrect
+}
+
+unless Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] > Hash[String, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] > Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, baz => String }] > Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct >= Integer {
+    fail incorrect
+}
+
+unless Struct >= Struct {
+    fail incorrect
+}
+
+if Struct >= Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+unless Struct[{ foo => Numeric }] >= Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Integer }] >= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+unless Struct[{ Optional[foo] => Integer, bar => Integer }] >= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => Integer, bar => Integer }] >= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct >= Hash {
+    fail incorrect
+}
+
+unless Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] >= Hash[String, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] >= Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, baz => String }] >= Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct < Integer {
+    fail incorrect
+}
+
+if Struct < Struct {
+    fail incorrect
+}
+
+if Struct < Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Numeric }] < Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Integer }] < Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ Optional[foo] => Integer, bar => Integer }] < Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => Integer, bar => Integer }] < Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+unless Struct < Hash {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] < Hash[String, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] < Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, baz => String }] < Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct <= Integer {
+    fail incorrect
+}
+
+unless Struct <= Struct {
+    fail incorrect
+}
+
+if Struct <= Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Numeric }] <= Struct[{ foo => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ foo => Integer }] <= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ Optional[foo] => Integer, bar => Integer }] <= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => Integer, bar => Integer }] <= Struct[{ bar => Integer }] {
+    fail incorrect
+}
+
+unless Struct <= Hash {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] <= Hash[String, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, Optional[baz] => String }] <= Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+if Struct[{ NotUndef[foo] => String, bar => String, baz => String }] <= Hash[Integer, String, 2, 2] {
+    fail incorrect
+}
+
+# Tuple tests
+
+unless Tuple == Tuple and Tuple[String, Integer] == Tuple[String, Integer] and Tuple[String, Numeric] != Tuple[String, Integer] and
+       Tuple[String, Numeric, 5] == Tuple[String, Numeric, 5] and Tuple[String, Numeric, 5, 10] == Tuple[String, Numeric, 5, 10] and
+       Tuple[String, Numeric, 5, 10] != Tuple[String, Numeric, 20, 100] {
+   fail incorrect
+}
+
+if Tuple > String {
+    fail incorrect
+}
+
+unless Tuple > Array {
+    fail incorrect
+}
+
+unless Tuple[Numeric, Integer, Numeric] > Array[Integer, 3, 3] {
+    fail incorrect
+}
+
+if Tuple[String] > Array[Integer, 1, 1] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, 0, 10] > Array[Integer, 0, 5] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] > Array[Integer, 10, 20] {
+    fail incorrect
+}
+
+if Tuple > Tuple {
+    fail incorrect
+}
+
+if Tuple[String] > Tuple {
+    fail incorrect
+}
+
+if Tuple[String] > Tuple[String] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, String] > Tuple[Integer, String] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, String, 3, 3] > Tuple[Integer, String, String] {
+    fail incorrect
+}
+
+if Tuple >= String {
+    fail incorrect
+}
+
+unless Tuple >= Array {
+    fail incorrect
+}
+
+unless Tuple[Numeric, Integer, Numeric] >= Array[Integer, 3, 3] {
+    fail incorrect
+}
+
+if Tuple[String] >= Array[Integer, 1, 1] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, 0, 10] >= Array[Integer, 0, 5] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] >= Array[Integer, 10, 20] {
+    fail incorrect
+}
+
+unless Tuple >= Tuple {
+    fail incorrect
+}
+
+if Tuple[String] >= Tuple {
+    fail incorrect
+}
+
+unless Tuple[String] >= Tuple[String] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, String] >= Tuple[Integer, String] {
+    fail incorrect
+}
+
+unless Tuple[Numeric, String, 3, 3] >= Tuple[Integer, String, String] {
+    fail incorrect
+}
+
+if Tuple < String {
+    fail incorrect
+}
+
+if Tuple < Array {
+    fail incorrect
+}
+
+if Tuple[Numeric, Integer, Numeric] < Array[Integer, 3, 3] {
+    fail incorrect
+}
+
+if Tuple[String] < Array[Integer, 1, 1] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] < Array[Integer, 0, 5] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] < Array[Integer, 10, 20] {
+    fail incorrect
+}
+
+if Tuple < Tuple {
+    fail incorrect
+}
+
+unless Tuple[String] < Tuple {
+    fail incorrect
+}
+
+if Tuple[String] < Tuple[String] {
+    fail incorrect
+}
+
+if Tuple[Numeric, String] < Tuple[Integer, String] {
+    fail incorrect
+}
+
+if Tuple[Numeric, String, 3, 3] < Tuple[Integer, String, String] {
+    fail incorrect
+}
+
+if Tuple <= String {
+    fail incorrect
+}
+
+if Tuple <= Array {
+    fail incorrect
+}
+
+if Tuple[Numeric, Integer, Numeric] <= Array[Integer, 3, 3] {
+    fail incorrect
+}
+
+if Tuple[String] <= Array[Integer, 1, 1] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] <= Array[Integer, 0, 5] {
+    fail incorrect
+}
+
+if Tuple[Numeric, 0, 10] <= Array[Integer, 10, 20] {
+    fail incorrect
+}
+
+unless Tuple <= Tuple {
+    fail incorrect
+}
+
+unless Tuple[String] <= Tuple {
+    fail incorrect
+}
+
+unless Tuple[String] <= Tuple[String] {
+    fail incorrect
+}
+
+if Tuple[Numeric, String] <= Tuple[Integer, String] {
+    fail incorrect
+}
+
+if Tuple[Numeric, String, 3, 3] <= Tuple[Integer, String, String] {
+    fail incorrect
+}
+
+# Type tests
+
+unless Type == Type and Type[String] == Type[String] and Type[Numeric] != Type[Integer] {
+    fail incorrect
+}
+
+if Type > String {
+    fail incorrect
+}
+
+if Type > Type {
+    fail incorrect
+}
+
+unless Type > Type[String] {
+    fail incorrect
+}
+
+unless Type[Numeric] > Type[Integer] {
+    fail incorrect
+}
+
+if Type[Numeric] > Type[String] {
+    fail incorrect
+}
+
+if Type >= String {
+    fail incorrect
+}
+
+unless Type >= Type {
+    fail incorrect
+}
+
+unless Type >= Type[String] {
+    fail incorrect
+}
+
+unless Type[Numeric] >= Type[Integer] {
+    fail incorrect
+}
+
+if Type[Numeric] >= Type[String] {
+    fail incorrect
+}
+
+if Type < String {
+    fail incorrect
+}
+
+if Type < Type {
+    fail incorrect
+}
+
+if Type < Type[String] {
+    fail incorrect
+}
+
+if Type[Numeric] < Type[Integer] {
+    fail incorrect
+}
+
+if Type[Numeric] < Type[String] {
+    fail incorrect
+}
+
+if Type <= String {
+    fail incorrect
+}
+
+unless Type <= Type {
+    fail incorrect
+}
+
+if Type <= Type[String] {
+    fail incorrect
+}
+
+if Type[Numeric] <= Type[Integer] {
+    fail incorrect
+}
+
+if Type[Numeric] <= Type[String] {
+    fail incorrect
+}
+
+# Undef tests
+
+unless Undef == Undef and Undef != Integer {
+    fail incorrect
+}
+
+if Undef > String {
+    fail incorrect
+}
+
+if Undef > Undef {
+    fail incorrect
+}
+
+if Undef >= String {
+    fail incorrect
+}
+
+unless Undef >= Undef {
+    fail incorrect
+}
+
+if Undef < String {
+    fail incorrect
+}
+
+if Undef < Undef {
+    fail incorrect
+}
+
+if Undef <= String {
+    fail incorrect
+}
+
+unless Undef <= Undef {
+    fail incorrect
+}
+
+# Variant tests
+
+unless Variant == Variant and Variant[String] == Variant[String] and Variant[String, Integer] == Variant[Integer, String] and Variant[String, Numeric] != Variant[Integer, String] {
+    fail incorrect
+}
+
+if Variant > Variant {
+    fail incorrect
+}
+
+if Variant > Variant[String] {
+    fail incorrect
+}
+
+unless Variant[Numeric] > Variant[Integer] {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] > Variant[String, Float] {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] > String {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] > Float {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Integer]] > String {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Regexp]] > Variant[Integer, Float] {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Regexp]] > Regexp {
+    fail incorrect
+}
+
+unless Variant >= Variant {
+    fail incorrect
+}
+
+if Variant >= Variant[String] {
+    fail incorrect
+}
+
+unless Variant[Numeric] >= Variant[Integer] {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] >= Variant[String, Float] {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] >= String {
+    fail incorrect
+}
+
+unless Variant[Numeric, String] >= Float {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Integer]] >= String {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Regexp]] >= Variant[Integer, Float] {
+    fail incorrect
+}
+
+unless Variant[Numeric, Variant[String, Regexp]] >= Regexp {
+    fail incorrect
+}
+
+if Variant < Variant {
+    fail incorrect
+}
+
+unless Variant < Variant[String] {
+    fail incorrect
+}
+
+if Variant[Numeric] < Variant[Integer] {
+    fail incorrect
+}
+
+if Variant[Numeric, String] < Variant[String, Float] {
+    fail incorrect
+}
+
+if Variant[Numeric, String] < String {
+    fail incorrect
+}
+
+if Variant[Numeric, String] < Float {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Integer]] < String {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Regexp]] < Variant[Integer, Float] {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Regexp]] < Regexp {
+    fail incorrect
+}
+
+unless Variant <= Variant {
+    fail incorrect
+}
+
+unless Variant <= Variant[String] {
+    fail incorrect
+}
+
+if Variant[Numeric] <= Variant[Integer] {
+    fail incorrect
+}
+
+if Variant[Numeric, String] <= Variant[String, Float] {
+    fail incorrect
+}
+
+if Variant[Numeric, String] <= String {
+    fail incorrect
+}
+
+if Variant[Numeric, String] <= Float {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Integer]] <= String {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Regexp]] <= Variant[Integer, Float] {
+    fail incorrect
+}
+
+if Variant[Numeric, Variant[String, Regexp]] <= Regexp {
+    fail incorrect
+}

--- a/lib/tests/fixtures/compiler/evaluation/type_hashing.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/type_hashing.baseline
@@ -1,0 +1,50 @@
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/type_hashing.pp
+++ b/lib/tests/fixtures/compiler/evaluation/type_hashing.pp
@@ -1,0 +1,177 @@
+unless {Any => true}[Any] {
+    fail incorrect
+}
+
+type Foo = Integer
+unless {Foo => true, Integer => false}[Foo] {
+    fail incorrect
+}
+
+unless {Boolean => true}[Boolean] {
+    fail incorrect
+}
+
+unless {Callable[Integer, default, default, Callable[String]] => true}[Callable[Integer, default, default, Callable[String]]] {
+    fail incorrect
+}
+
+unless {CatalogEntry => true}[CatalogEntry] {
+    fail incorrect
+}
+
+unless {Class => true}[Class] {
+    fail incorrect
+}
+unless {Class[foo] => true}[Class[foo]] {
+    fail incorrect
+}
+
+unless {Collection[5, 10] => true}[Collection[5, 10]] {
+    fail incorrect
+}
+
+unless {Data => true}[Data] {
+    fail incorrect
+}
+
+unless {Default => true}[Default] {
+    fail incorrect
+}
+
+unless {Enum => true}[Enum] {
+    fail incorrect
+}
+
+unless {Enum[foo, bar] => true}[Enum[foo, bar]] {
+    fail incorrect
+}
+
+unless {Float => true}[Float] {
+    fail incorrect
+}
+
+unless {Float[10, 11] => true}[Float[10, 11]] {
+    fail incorrect
+}
+
+unless {Hash => true}[Hash] {
+    fail incorrect
+}
+
+unless {Hash[String, Integer, 0, 10] => true}[Hash[String, Integer, 0, 10]] {
+    fail incorrect
+}
+
+unless {Integer => true}[Integer] {
+    fail incorrect
+}
+
+unless {Integer[0, 100] => true}[Integer[0, 100]] {
+    fail incorrect
+}
+
+unless {Iterable => true}[Iterable] {
+    fail incorrect
+}
+unless {Iterable[String] => true}[Iterable[String]] {
+    fail incorrect
+}
+
+unless {Iterator => true}[Iterator] {
+    fail incorrect
+}
+unless {Iterator[String] => true}[Iterator[String]] {
+    fail incorrect
+}
+
+unless {NotUndef => true}[NotUndef] {
+    fail incorrect
+}
+unless {NotUndef[Boolean] => true}[NotUndef[Boolean]] {
+    fail incorrect
+}
+
+unless {Numeric => true}[Numeric] {
+    fail incorrect
+}
+
+unless {Optional => true}[Optional] {
+    fail incorrect
+}
+unless {Optional[String] => true}[Optional[String]] {
+    fail incorrect
+}
+
+unless {Pattern => true}[Pattern] {
+    fail incorrect
+}
+unless {Pattern[/foo/] => true}[Pattern[/foo/]] {
+    fail incorrect
+}
+
+unless {Regexp => true}[Regexp] {
+    fail incorrect
+}
+unless {Regexp[/foo/] => true}[Regexp[/foo/]] {
+    fail incorrect
+}
+
+unless {Resource => true}[Resource] {
+    fail incorrect
+}
+unless {Resource[foo, bar] => true}[Resource[foo, bar]] {
+    fail incorrect
+}
+
+unless {Runtime => true}[Runtime] {
+    fail incorrect
+}
+unless {Runtime[foo, bar] => true}[Runtime[foo, bar]] {
+    fail incorrect
+}
+
+unless {Scalar => true}[Scalar] {
+    fail incorrect
+}
+
+unless {String => true}[String] {
+    fail incorrect
+}
+unless {String[0, 10] => true}[String[0, 10]] {
+    fail incorrect
+}
+
+unless {Struct => true}[Struct] {
+    fail incorrect
+}
+unless {Struct[{foo => String}] => true}[Struct[{foo => String}]] {
+    fail incorrect
+}
+
+unless {Tuple => true}[Tuple] {
+    fail incorrect
+}
+unless {Tuple[String, Integer, 2, 2] => true}[Tuple[String, Integer, 2, 2]] {
+    fail incorrect
+}
+
+unless {Type => true}[Type] {
+    fail incorrect
+}
+unless {Tuple[Integer[0, 10]] => true}[Tuple[Integer[0, 10]]] {
+    fail incorrect
+}
+
+unless {Undef => true}[Undef] {
+    fail incorrect
+}
+
+unless {Variant => true}[Variant] {
+    fail incorrect
+}
+unless {Variant[String, Integer] => true}[Variant[String, Integer]] {
+    fail incorrect
+}
+if {Variant[String, Integer] => true}[Variant[Integer, String]] {
+    fail incorrect
+}

--- a/lib/tests/fixtures/compiler/parser/good/sample.baseline
+++ b/lib/tests/fixtures/compiler/parser/good/sample.baseline
@@ -7119,27 +7119,27 @@ statements:
               offset: 5107
               line: 342
             value: incorrect
-  - kind: if
+  - kind: unless
     begin:
       offset: 5110
       line: 344
     end:
-      offset: 5157
+      offset: 5161
       line: 346
     conditional:
       kind: binary
       first:
         kind: type
         begin:
-          offset: 5113
+          offset: 5117
           line: 344
         end:
-          offset: 5119
+          offset: 5123
           line: 344
         name: String
       operations:
         - operator_position:
-            offset: 5120
+            offset: 5124
             line: 344
           operator: ">"
           operand:
@@ -7147,36 +7147,36 @@ statements:
             primary:
               kind: type
               begin:
-                offset: 5122
+                offset: 5126
                 line: 344
               end:
-                offset: 5128
+                offset: 5132
                 line: 344
               name: String
             subexpressions:
               - kind: access
                 begin:
-                  offset: 5128
+                  offset: 5132
                   line: 344
                 end:
-                  offset: 5134
+                  offset: 5138
                   line: 344
                 arguments:
                   - kind: number
                     begin:
-                      offset: 5129
+                      offset: 5133
                       line: 344
                     end:
-                      offset: 5130
+                      offset: 5134
                       line: 344
                     base: decimal
                     value: 0
                   - kind: number
                     begin:
-                      offset: 5132
+                      offset: 5136
                       line: 344
                     end:
-                      offset: 5133
+                      offset: 5137
                       line: 344
                     base: decimal
                     value: 0
@@ -7185,24 +7185,24 @@ statements:
         function:
           kind: name
           begin:
-            offset: 5141
+            offset: 5145
             line: 345
           end:
-            offset: 5145
+            offset: 5149
             line: 345
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 5146
+              offset: 5150
               line: 345
             end:
-              offset: 5155
+              offset: 5159
               line: 345
             value: incorrect
-  - kind: unless
+  - kind: if
     begin:
-      offset: 5158
+      offset: 5162
       line: 347
     end:
       offset: 5209
@@ -8033,27 +8033,27 @@ statements:
               offset: 5720
               line: 388
             value: incorrect
-  - kind: if
+  - kind: unless
     begin:
       offset: 5723
       line: 390
     end:
-      offset: 5771
+      offset: 5775
       line: 392
     conditional:
       kind: binary
       first:
         kind: type
         begin:
-          offset: 5726
+          offset: 5730
           line: 390
         end:
-          offset: 5732
+          offset: 5736
           line: 390
         name: String
       operations:
         - operator_position:
-            offset: 5733
+            offset: 5737
             line: 390
           operator: ">="
           operand:
@@ -8061,36 +8061,36 @@ statements:
             primary:
               kind: type
               begin:
-                offset: 5736
+                offset: 5740
                 line: 390
               end:
-                offset: 5742
+                offset: 5746
                 line: 390
               name: String
             subexpressions:
               - kind: access
                 begin:
-                  offset: 5742
+                  offset: 5746
                   line: 390
                 end:
-                  offset: 5748
+                  offset: 5752
                   line: 390
                 arguments:
                   - kind: number
                     begin:
-                      offset: 5743
+                      offset: 5747
                       line: 390
                     end:
-                      offset: 5744
+                      offset: 5748
                       line: 390
                     base: decimal
                     value: 0
                   - kind: number
                     begin:
-                      offset: 5746
+                      offset: 5750
                       line: 390
                     end:
-                      offset: 5747
+                      offset: 5751
                       line: 390
                     base: decimal
                     value: 0
@@ -8099,24 +8099,24 @@ statements:
         function:
           kind: name
           begin:
-            offset: 5755
+            offset: 5759
             line: 391
           end:
-            offset: 5759
+            offset: 5763
             line: 391
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 5760
+              offset: 5764
               line: 391
             end:
-              offset: 5769
+              offset: 5773
               line: 391
             value: incorrect
-  - kind: unless
+  - kind: if
     begin:
-      offset: 5772
+      offset: 5776
       line: 393
     end:
       offset: 5824
@@ -10386,27 +10386,27 @@ statements:
               offset: 7200
               line: 490
             value: incorrect
-  - kind: unless
+  - kind: if
     begin:
       offset: 7203
       line: 492
     end:
-      offset: 7254
+      offset: 7250
       line: 494
     conditional:
       kind: binary
       first:
         kind: type
         begin:
-          offset: 7210
+          offset: 7206
           line: 492
         end:
-          offset: 7216
+          offset: 7212
           line: 492
         name: String
       operations:
         - operator_position:
-            offset: 7217
+            offset: 7213
             line: 492
           operator: <
           operand:
@@ -10414,36 +10414,36 @@ statements:
             primary:
               kind: type
               begin:
-                offset: 7219
+                offset: 7215
                 line: 492
               end:
-                offset: 7225
+                offset: 7221
                 line: 492
               name: String
             subexpressions:
               - kind: access
                 begin:
-                  offset: 7225
+                  offset: 7221
                   line: 492
                 end:
-                  offset: 7231
+                  offset: 7227
                   line: 492
                 arguments:
                   - kind: number
                     begin:
-                      offset: 7226
+                      offset: 7222
                       line: 492
                     end:
-                      offset: 7227
+                      offset: 7223
                       line: 492
                     base: decimal
                     value: 0
                   - kind: number
                     begin:
-                      offset: 7229
+                      offset: 7225
                       line: 492
                     end:
-                      offset: 7230
+                      offset: 7226
                       line: 492
                     base: decimal
                     value: 0
@@ -10452,24 +10452,24 @@ statements:
         function:
           kind: name
           begin:
-            offset: 7238
+            offset: 7234
             line: 493
           end:
-            offset: 7242
+            offset: 7238
             line: 493
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 7243
+              offset: 7239
               line: 493
             end:
-              offset: 7252
+              offset: 7248
               line: 493
             value: incorrect
-  - kind: if
+  - kind: unless
     begin:
-      offset: 7255
+      offset: 7251
       line: 495
     end:
       offset: 7302
@@ -11300,27 +11300,27 @@ statements:
               offset: 7813
               line: 536
             value: incorrect
-  - kind: unless
+  - kind: if
     begin:
       offset: 7816
       line: 538
     end:
-      offset: 7868
+      offset: 7864
       line: 540
     conditional:
       kind: binary
       first:
         kind: type
         begin:
-          offset: 7823
+          offset: 7819
           line: 538
         end:
-          offset: 7829
+          offset: 7825
           line: 538
         name: String
       operations:
         - operator_position:
-            offset: 7830
+            offset: 7826
             line: 538
           operator: <=
           operand:
@@ -11328,36 +11328,36 @@ statements:
             primary:
               kind: type
               begin:
-                offset: 7833
+                offset: 7829
                 line: 538
               end:
-                offset: 7839
+                offset: 7835
                 line: 538
               name: String
             subexpressions:
               - kind: access
                 begin:
-                  offset: 7839
+                  offset: 7835
                   line: 538
                 end:
-                  offset: 7845
+                  offset: 7841
                   line: 538
                 arguments:
                   - kind: number
                     begin:
-                      offset: 7840
+                      offset: 7836
                       line: 538
                     end:
-                      offset: 7841
+                      offset: 7837
                       line: 538
                     base: decimal
                     value: 0
                   - kind: number
                     begin:
-                      offset: 7843
+                      offset: 7839
                       line: 538
                     end:
-                      offset: 7844
+                      offset: 7840
                       line: 538
                     base: decimal
                     value: 0
@@ -11366,24 +11366,24 @@ statements:
         function:
           kind: name
           begin:
-            offset: 7852
+            offset: 7848
             line: 539
           end:
-            offset: 7856
+            offset: 7852
             line: 539
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 7857
+              offset: 7853
               line: 539
             end:
-              offset: 7866
+              offset: 7862
               line: 539
             value: incorrect
-  - kind: if
+  - kind: unless
     begin:
-      offset: 7869
+      offset: 7865
       line: 541
     end:
       offset: 7917
@@ -17953,7 +17953,7 @@ statements:
       offset: 11816
       line: 789
     end:
-      offset: 11913
+      offset: 11914
       line: 791
     conditional:
       kind: binary
@@ -17983,51 +17983,51 @@ statements:
         - operator_position:
             offset: 11838
             line: 789
-          operator: or
+          operator: and
           operand:
             kind: interpolated string
             begin:
-              offset: 11841
+              offset: 11842
               line: 789
             end:
-              offset: 11865
+              offset: 11866
               line: 789
             parts:
               - kind: literal text
                 begin:
-                  offset: 11842
+                  offset: 11843
                   line: 789
                 end:
-                  offset: 11859
+                  offset: 11860
                   line: 789
                 text: match group 1 = '
               - kind: variable
                 begin:
-                  offset: 11861
+                  offset: 11862
                   line: 789
                 end:
-                  offset: 11862
+                  offset: 11863
                   line: 789
                 name: 1
               - kind: literal text
                 begin:
-                  offset: 11863
+                  offset: 11864
                   line: 789
                 end:
-                  offset: 11864
+                  offset: 11865
                   line: 789
                 text: "'"
         - operator_position:
-            offset: 11866
+            offset: 11867
             line: 789
           operator: ==
           operand:
             kind: string
             begin:
-              offset: 11869
+              offset: 11870
               line: 789
             end:
-              offset: 11890
+              offset: 11891
               line: 789
             value: match group 1 = 'o'
     body:
@@ -18035,59 +18035,59 @@ statements:
         function:
           kind: name
           begin:
-            offset: 11897
+            offset: 11898
             line: 790
           end:
-            offset: 11901
+            offset: 11902
             line: 790
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 11902
+              offset: 11903
               line: 790
             end:
-              offset: 11911
+              offset: 11912
               line: 790
             value: incorrect
   - kind: unless
     begin:
-      offset: 11914
+      offset: 11915
       line: 792
     end:
-      offset: 11973
+      offset: 11974
       line: 794
     conditional:
       kind: binary
       first:
         kind: interpolated string
         begin:
-          offset: 11921
+          offset: 11922
           line: 792
         end:
-          offset: 11943
+          offset: 11944
           line: 792
         parts:
           - kind: variable
             begin:
-              offset: 11926
+              offset: 11927
               line: 792
             end:
-              offset: 11938
+              offset: 11939
               line: 792
             name: interpolated
       operations:
         - operator_position:
-            offset: 11944
+            offset: 11945
             line: 792
           operator: ==
           operand:
             kind: name
             begin:
-              offset: 11947
+              offset: 11948
               line: 792
             end:
-              offset: 11950
+              offset: 11951
               line: 792
             value: foo
     body:
@@ -18095,59 +18095,59 @@ statements:
         function:
           kind: name
           begin:
-            offset: 11957
+            offset: 11958
             line: 793
           end:
-            offset: 11961
+            offset: 11962
             line: 793
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 11962
+              offset: 11963
               line: 793
             end:
-              offset: 11971
+              offset: 11972
               line: 793
             value: incorrect
   - kind: unless
     begin:
-      offset: 11974
+      offset: 11975
       line: 795
     end:
-      offset: 12031
+      offset: 12032
       line: 797
     conditional:
       kind: binary
       first:
         kind: interpolated string
         begin:
-          offset: 11981
+          offset: 11982
           line: 795
         end:
-          offset: 12001
+          offset: 12002
           line: 795
         parts:
           - kind: variable
             begin:
-              offset: 11984
+              offset: 11985
               line: 795
             end:
-              offset: 11996
+              offset: 11997
               line: 795
             name: interpolated
       operations:
         - operator_position:
-            offset: 12002
+            offset: 12003
             line: 795
           operator: ==
           operand:
             kind: name
             begin:
-              offset: 12005
+              offset: 12006
               line: 795
             end:
-              offset: 12008
+              offset: 12009
               line: 795
             value: foo
     body:
@@ -18155,59 +18155,59 @@ statements:
         function:
           kind: name
           begin:
-            offset: 12015
+            offset: 12016
             line: 796
           end:
-            offset: 12019
+            offset: 12020
             line: 796
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12020
+              offset: 12021
               line: 796
             end:
-              offset: 12029
+              offset: 12030
               line: 796
             value: incorrect
   - kind: unless
     begin:
-      offset: 12032
+      offset: 12033
       line: 798
     end:
-      offset: 12089
+      offset: 12090
       line: 800
     conditional:
       kind: binary
       first:
         kind: interpolated string
         begin:
-          offset: 12039
+          offset: 12040
           line: 798
         end:
-          offset: 12059
+          offset: 12060
           line: 798
         parts:
           - kind: variable
             begin:
-              offset: 12045
+              offset: 12046
               line: 798
             end:
-              offset: 12057
+              offset: 12058
               line: 798
             name: interpolated
       operations:
         - operator_position:
-            offset: 12060
+            offset: 12061
             line: 798
           operator: ==
           operand:
             kind: name
             begin:
-              offset: 12063
+              offset: 12064
               line: 798
             end:
-              offset: 12066
+              offset: 12067
               line: 798
             value: foo
     body:
@@ -18215,93 +18215,93 @@ statements:
         function:
           kind: name
           begin:
-            offset: 12073
+            offset: 12074
             line: 799
           end:
-            offset: 12077
+            offset: 12078
             line: 799
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12078
+              offset: 12079
               line: 799
             end:
-              offset: 12087
+              offset: 12088
               line: 799
             value: incorrect
   - kind: resource defaults
     begin:
-      offset: 12111
+      offset: 12112
       line: 803
     end:
-      offset: 12134
+      offset: 12135
       line: 805
     type:
       kind: type
       begin:
-        offset: 12111
+        offset: 12112
         line: 803
       end:
-        offset: 12115
+        offset: 12116
         line: 803
       name: File
     operations:
       - name:
           kind: name
           begin:
-            offset: 12122
+            offset: 12123
             line: 804
           end:
-            offset: 12125
+            offset: 12126
             line: 804
           value: foo
         operator_position:
-          offset: 12126
+          offset: 12127
           line: 804
         operator: =>
         value:
           kind: name
           begin:
-            offset: 12129
+            offset: 12130
             line: 804
           end:
-            offset: 12132
+            offset: 12133
             line: 804
           value: bar
   - kind: resource
     begin:
-      offset: 12136
+      offset: 12137
       line: 807
     end:
-      offset: 12162
+      offset: 12163
       line: 808
     status: realized
     type:
       kind: name
       begin:
-        offset: 12136
+        offset: 12137
         line: 807
       end:
-        offset: 12140
+        offset: 12141
         line: 807
       value: file
     bodies:
       - title:
           kind: string
           begin:
-            offset: 12143
+            offset: 12144
             line: 807
           end:
-            offset: 12159
+            offset: 12160
             line: 807
           value: /default/check
   - kind: unless
     begin:
-      offset: 12164
+      offset: 12165
       line: 810
     end:
-      offset: 12228
+      offset: 12229
       line: 812
     conditional:
       kind: binary
@@ -18310,57 +18310,57 @@ statements:
         primary:
           kind: type
           begin:
-            offset: 12171
+            offset: 12172
             line: 810
           end:
-            offset: 12175
+            offset: 12176
             line: 810
           name: File
         subexpressions:
           - kind: access
             begin:
-              offset: 12175
+              offset: 12176
               line: 810
             end:
-              offset: 12193
+              offset: 12194
               line: 810
             arguments:
               - kind: string
                 begin:
-                  offset: 12176
+                  offset: 12177
                   line: 810
                 end:
-                  offset: 12192
+                  offset: 12193
                   line: 810
                 value: /default/check
           - kind: access
             begin:
-              offset: 12193
+              offset: 12194
               line: 810
             end:
-              offset: 12198
+              offset: 12199
               line: 810
             arguments:
               - kind: name
                 begin:
-                  offset: 12194
+                  offset: 12195
                   line: 810
                 end:
-                  offset: 12197
+                  offset: 12198
                   line: 810
                 value: foo
       operations:
         - operator_position:
-            offset: 12199
+            offset: 12200
             line: 810
           operator: ==
           operand:
             kind: name
             begin:
-              offset: 12202
+              offset: 12203
               line: 810
             end:
-              offset: 12205
+              offset: 12206
               line: 810
             value: bar
     body:
@@ -18368,85 +18368,85 @@ statements:
         function:
           kind: name
           begin:
-            offset: 12212
+            offset: 12213
             line: 811
           end:
-            offset: 12216
+            offset: 12217
             line: 811
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12217
+              offset: 12218
               line: 811
             end:
-              offset: 12226
+              offset: 12227
               line: 811
             value: incorrect
   - kind: resource override
     begin:
-      offset: 12252
+      offset: 12253
       line: 816
     end:
-      offset: 12294
+      offset: 12295
       line: 818
     reference:
       kind: postfix
       primary:
         kind: type
         begin:
-          offset: 12252
+          offset: 12253
           line: 816
         end:
-          offset: 12256
+          offset: 12257
           line: 816
         name: File
       subexpressions:
         - kind: access
           begin:
-            offset: 12256
+            offset: 12257
             line: 816
           end:
-            offset: 12274
+            offset: 12275
             line: 816
           arguments:
             - kind: string
               begin:
-                offset: 12257
+                offset: 12258
                 line: 816
               end:
-                offset: 12273
+                offset: 12274
                 line: 816
               value: /default/check
     operations:
       - name:
           kind: name
           begin:
-            offset: 12281
+            offset: 12282
             line: 817
           end:
-            offset: 12284
+            offset: 12285
             line: 817
           value: baz
         operator_position:
-          offset: 12285
+          offset: 12286
           line: 817
         operator: =>
         value:
           kind: name
           begin:
-            offset: 12288
+            offset: 12289
             line: 817
           end:
-            offset: 12292
+            offset: 12293
             line: 817
           value: cake
   - kind: unless
     begin:
-      offset: 12296
+      offset: 12297
       line: 820
     end:
-      offset: 12361
+      offset: 12362
       line: 822
     conditional:
       kind: binary
@@ -18455,57 +18455,57 @@ statements:
         primary:
           kind: type
           begin:
-            offset: 12303
+            offset: 12304
             line: 820
           end:
-            offset: 12307
+            offset: 12308
             line: 820
           name: File
         subexpressions:
           - kind: access
             begin:
-              offset: 12307
+              offset: 12308
               line: 820
             end:
-              offset: 12325
+              offset: 12326
               line: 820
             arguments:
               - kind: string
                 begin:
-                  offset: 12308
+                  offset: 12309
                   line: 820
                 end:
-                  offset: 12324
+                  offset: 12325
                   line: 820
                 value: /default/check
           - kind: access
             begin:
-              offset: 12325
+              offset: 12326
               line: 820
             end:
-              offset: 12330
+              offset: 12331
               line: 820
             arguments:
               - kind: name
                 begin:
-                  offset: 12326
+                  offset: 12327
                   line: 820
                 end:
-                  offset: 12329
+                  offset: 12330
                   line: 820
                 value: baz
       operations:
         - operator_position:
-            offset: 12331
+            offset: 12332
             line: 820
           operator: ==
           operand:
             kind: name
             begin:
-              offset: 12334
+              offset: 12335
               line: 820
             end:
-              offset: 12338
+              offset: 12339
               line: 820
             value: cake
     body:
@@ -18513,138 +18513,138 @@ statements:
         function:
           kind: name
           begin:
-            offset: 12345
+            offset: 12346
             line: 821
           end:
-            offset: 12349
+            offset: 12350
             line: 821
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12350
+              offset: 12351
               line: 821
             end:
-              offset: 12359
+              offset: 12360
               line: 821
             value: incorrect
   - kind: function
     begin:
-      offset: 12381
+      offset: 12382
       line: 826
     end:
-      offset: 12417
+      offset: 12418
       line: 828
     name:
       kind: name
       begin:
-        offset: 12390
+        offset: 12391
         line: 826
       end:
-        offset: 12404
+        offset: 12405
         line: 826
       value: test::noparams
     body:
       - kind: boolean
         begin:
-          offset: 12411
+          offset: 12412
           line: 827
         end:
-          offset: 12415
+          offset: 12416
           line: 827
         value: true
   - kind: unless
     begin:
-      offset: 12419
+      offset: 12420
       line: 830
     end:
-      offset: 12465
+      offset: 12466
       line: 832
     conditional:
       kind: function call
       function:
         kind: name
         begin:
-          offset: 12426
+          offset: 12427
           line: 830
         end:
-          offset: 12440
+          offset: 12441
           line: 830
         value: test::noparams
       end:
-        offset: 12442
+        offset: 12443
         line: 830
     body:
       - kind: function call
         function:
           kind: name
           begin:
-            offset: 12449
+            offset: 12450
             line: 831
           end:
-            offset: 12453
+            offset: 12454
             line: 831
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12454
+              offset: 12455
               line: 831
             end:
-              offset: 12463
+              offset: 12464
               line: 831
             value: incorrect
   - kind: function
     begin:
-      offset: 12467
+      offset: 12468
       line: 834
     end:
-      offset: 12546
+      offset: 12547
       line: 836
     name:
       kind: name
       begin:
-        offset: 12476
+        offset: 12477
         line: 834
       end:
-        offset: 12493
+        offset: 12494
         line: 834
       value: test::typedparams
     parameters:
       - type:
           kind: type
           begin:
-            offset: 12494
+            offset: 12495
             line: 834
           end:
-            offset: 12501
+            offset: 12502
             line: 834
           name: Integer
         variable:
           kind: variable
           begin:
-            offset: 12502
+            offset: 12503
             line: 834
           end:
-            offset: 12504
+            offset: 12505
             line: 834
           name: a
       - type:
           kind: type
           begin:
-            offset: 12506
+            offset: 12507
             line: 834
           end:
-            offset: 12512
+            offset: 12513
             line: 834
           name: String
         variable:
           kind: variable
           begin:
-            offset: 12513
+            offset: 12514
             line: 834
           end:
-            offset: 12515
+            offset: 12516
             line: 834
           name: b
     body:
@@ -18652,157 +18652,157 @@ statements:
         first:
           kind: variable
           begin:
-            offset: 12523
+            offset: 12524
             line: 835
           end:
-            offset: 12525
+            offset: 12526
             line: 835
           name: a
         operations:
           - operator_position:
-              offset: 12526
+              offset: 12527
               line: 835
             operator: ==
             operand:
               kind: number
               begin:
-                offset: 12529
+                offset: 12530
                 line: 835
               end:
-                offset: 12530
+                offset: 12531
                 line: 835
               base: decimal
               value: 1
           - operator_position:
-              offset: 12531
+              offset: 12532
               line: 835
             operator: and
             operand:
               kind: variable
               begin:
-                offset: 12535
+                offset: 12536
                 line: 835
               end:
-                offset: 12537
+                offset: 12538
                 line: 835
               name: b
           - operator_position:
-              offset: 12538
+              offset: 12539
               line: 835
             operator: ==
             operand:
               kind: name
               begin:
-                offset: 12541
+                offset: 12542
                 line: 835
               end:
-                offset: 12544
+                offset: 12545
                 line: 835
               value: foo
   - kind: unless
     begin:
-      offset: 12548
+      offset: 12549
       line: 838
     end:
-      offset: 12603
+      offset: 12604
       line: 840
     conditional:
       kind: function call
       function:
         kind: name
         begin:
-          offset: 12555
+          offset: 12556
           line: 838
         end:
-          offset: 12572
+          offset: 12573
           line: 838
         value: test::typedparams
       arguments:
         - kind: number
           begin:
-            offset: 12573
+            offset: 12574
             line: 838
           end:
-            offset: 12574
+            offset: 12575
             line: 838
           base: decimal
           value: 1
         - kind: name
           begin:
-            offset: 12576
+            offset: 12577
             line: 838
           end:
-            offset: 12579
+            offset: 12580
             line: 838
           value: foo
       end:
-        offset: 12580
+        offset: 12581
         line: 838
     body:
       - kind: function call
         function:
           kind: name
           begin:
-            offset: 12587
+            offset: 12588
             line: 839
           end:
-            offset: 12591
+            offset: 12592
             line: 839
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12592
+              offset: 12593
               line: 839
             end:
-              offset: 12601
+              offset: 12602
               line: 839
             value: incorrect
   - kind: function
     begin:
-      offset: 12605
+      offset: 12606
       line: 842
     end:
-      offset: 12692
+      offset: 12693
       line: 844
     name:
       kind: name
       begin:
-        offset: 12614
+        offset: 12615
         line: 842
       end:
-        offset: 12628
+        offset: 12629
         line: 842
       value: test::function
     parameters:
       - variable:
           kind: variable
           begin:
-            offset: 12629
+            offset: 12630
             line: 842
           end:
-            offset: 12631
+            offset: 12632
             line: 842
           name: a
       - variable:
           kind: variable
           begin:
-            offset: 12633
+            offset: 12634
             line: 842
           end:
-            offset: 12635
+            offset: 12636
             line: 842
           name: b
       - captures:
-          offset: 12637
+          offset: 12638
           line: 842
         variable:
           kind: variable
           begin:
-            offset: 12638
+            offset: 12639
             line: 842
           end:
-            offset: 12640
+            offset: 12641
             line: 842
           name: c
     body:
@@ -18810,167 +18810,167 @@ statements:
         first:
           kind: variable
           begin:
-            offset: 12648
+            offset: 12649
             line: 843
           end:
-            offset: 12650
+            offset: 12651
             line: 843
           name: a
         operations:
           - operator_position:
-              offset: 12651
+              offset: 12652
               line: 843
             operator: ==
             operand:
               kind: number
               begin:
-                offset: 12654
+                offset: 12655
                 line: 843
               end:
-                offset: 12655
+                offset: 12656
                 line: 843
               base: decimal
               value: 1
           - operator_position:
-              offset: 12656
+              offset: 12657
               line: 843
             operator: and
             operand:
               kind: variable
               begin:
-                offset: 12660
+                offset: 12661
                 line: 843
               end:
-                offset: 12662
+                offset: 12663
                 line: 843
               name: b
           - operator_position:
-              offset: 12663
+              offset: 12664
               line: 843
             operator: ==
             operand:
               kind: name
               begin:
-                offset: 12666
+                offset: 12667
                 line: 843
               end:
-                offset: 12669
+                offset: 12670
                 line: 843
               value: foo
           - operator_position:
-              offset: 12670
+              offset: 12671
               line: 843
             operator: and
             operand:
               kind: variable
               begin:
-                offset: 12674
+                offset: 12675
                 line: 843
               end:
-                offset: 12676
+                offset: 12677
                 line: 843
               name: c
           - operator_position:
-              offset: 12677
+              offset: 12678
               line: 843
             operator: ==
             operand:
               kind: array
               begin:
-                offset: 12680
+                offset: 12681
                 line: 843
               end:
-                offset: 12690
+                offset: 12691
                 line: 843
               elements:
                 - kind: name
                   begin:
-                    offset: 12681
+                    offset: 12682
                     line: 843
                   end:
-                    offset: 12684
+                    offset: 12685
                     line: 843
                   value: bar
                 - kind: name
                   begin:
-                    offset: 12686
+                    offset: 12687
                     line: 843
                   end:
-                    offset: 12689
+                    offset: 12690
                     line: 843
                   value: baz
   - kind: unless
     begin:
-      offset: 12694
+      offset: 12695
       line: 846
     end:
-      offset: 12756
+      offset: 12757
       line: 848
     conditional:
       kind: function call
       function:
         kind: name
         begin:
-          offset: 12701
+          offset: 12702
           line: 846
         end:
-          offset: 12715
+          offset: 12716
           line: 846
         value: test::function
       arguments:
         - kind: number
           begin:
-            offset: 12716
+            offset: 12717
             line: 846
           end:
-            offset: 12717
+            offset: 12718
             line: 846
           base: decimal
           value: 1
         - kind: name
           begin:
-            offset: 12719
+            offset: 12720
             line: 846
           end:
-            offset: 12722
+            offset: 12723
             line: 846
           value: foo
         - kind: name
           begin:
-            offset: 12724
+            offset: 12725
             line: 846
           end:
-            offset: 12727
+            offset: 12728
             line: 846
           value: bar
         - kind: name
           begin:
-            offset: 12729
+            offset: 12730
             line: 846
           end:
-            offset: 12732
+            offset: 12733
             line: 846
           value: baz
       end:
-        offset: 12733
+        offset: 12734
         line: 846
     body:
       - kind: function call
         function:
           kind: name
           begin:
-            offset: 12740
+            offset: 12741
             line: 847
           end:
-            offset: 12744
+            offset: 12745
             line: 847
           value: fail
         arguments:
           - kind: name
             begin:
-              offset: 12745
+              offset: 12746
               line: 847
             end:
-              offset: 12754
+              offset: 12755
               line: 847
             value: incorrect

--- a/lib/tests/fixtures/compiler/parser/good/sample.pp
+++ b/lib/tests/fixtures/compiler/parser/good/sample.pp
@@ -341,10 +341,10 @@ unless foo > bar {
 if foo > foo {
     fail incorrect
 }
-if String > String[0, 0] {
+unless String > String[0, 0] {
     fail incorrect
 }
-unless String[0, 0] > String {
+if String[0, 0] > String {
     fail incorrect
 }
 if String[0, 0] > String[0, 0] {
@@ -387,10 +387,10 @@ unless foo >= bar {
 unless foo >= foo {
     fail incorrect
 }
-if String >= String[0, 0] {
+unless String >= String[0, 0] {
     fail incorrect
 }
-unless String[0, 0] >= String {
+if String[0, 0] >= String {
     fail incorrect
 }
 unless String[0, 0] >= String[0, 0] {
@@ -489,10 +489,10 @@ if foo < bar {
 if foo < foo {
     fail incorrect
 }
-unless String < String[0, 0] {
+if String < String[0, 0] {
     fail incorrect
 }
-if String[0, 0] < String {
+unless String[0, 0] < String {
     fail incorrect
 }
 if String[0, 0] < String[0, 0] {
@@ -535,10 +535,10 @@ if foo <= bar {
 unless foo <= foo {
     fail incorrect
 }
-unless String <= String[0, 0] {
+if String <= String[0, 0] {
     fail incorrect
 }
-if String[0, 0] <= String {
+unless String[0, 0] <= String {
     fail incorrect
 }
 unless String[0, 0] <= String[0, 0] {
@@ -786,7 +786,7 @@ unless "\$interpolated[0] = ${interpolated[0]}" == "\$interpolated[0] = f" {
 unless "\$interpolated.split('') = ${interpolated.split('')}" == "\$interpolated.split('') = [f, o, o]" {
     fail incorrect
 }
-unless foo =~ /f(o)o/ or "match group 1 = '${1}'" == "match group 1 = 'o'" {
+unless foo =~ /f(o)o/ and "match group 1 = '${1}'" == "match group 1 = 'o'" {
     fail incorrect
 }
 unless "${  interpolated   }" == foo {


### PR DESCRIPTION
Previously a `is_specialization` function was implemented to implement the
comparison operators on types under the assumption the operators were answering
the question of "is this type more or less specific?".  However, the question
the operators answer is actually "is this type assignable?".  As such, this
commit replaces `is_specialization` with `is_assignable` and adheres to the
logic of `assignable?` from the Ruby implementation.

Additionally, a proper "recursion guard" was implemented to prevent infinite
recursion on type aliases which was missing for instance checking.

Since all types except `Variant` and type aliases returned `true` for
`is_real`, the `is_real` implementations were removed in favor of a much
simpler member function on `values::type` that does the same check.

Additional bugs were fixed as they were encountered while writing the
`type_comparisons.pp` test.