### PR TITLE
(NPUP-40) Replace references to GNU Readline with Editline.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${PROJECT_BINARY_DIR}/lib)
 find_package(Boost 1.60.0 REQUIRED COMPONENTS program_options filesystem system)
 find_package(Facter REQUIRED)
 find_package(YAMLCPP REQUIRED)
-find_package(Readline)
+find_package(Editline)
 
 # Display a summary of the features
 include(FeatureSummary)

--- a/README.md
+++ b/README.md
@@ -184,11 +184,11 @@ Build Requirements
 
 * OSX or Linux
 * GCC >= 5.0 or Clang >= 3.4 (with libc++)
-* CMake >= 3.0
-* Boost Libraries >= 1.60.0
+* [CMake](https://cmake.org/) >= 3.0
+* [Boost Libraries](http://www.boost.org/) >= 1.60.0
 * [Facter](https://github.com/puppetlabs/facter) >= 3.0
-* yaml-cpp >= 0.5.1
-* GNU readline (optional - improves the REPL experience)
+* [yaml-cpp](https://github.com/jbeder/yaml-cpp) >= 0.5.1
+* [Editline](http://thrysoee.dk/editline/) (optional - improves the REPL experience)
 
 Pre-Build
 ---------

--- a/cmake/FindEditline.cmake
+++ b/cmake/FindEditline.cmake
@@ -1,0 +1,7 @@
+include(FindDependency)
+
+find_dependency(Editline DISPLAY "editline" HEADERS "editline/readline.h" LIBRARIES "edit")
+
+include(FeatureSummary)
+set_package_properties(Editline PROPERTIES DESCRIPTION "A library for use by applications that allow users to edit command lines as they are typed in" URL "http://thrysoee.dk/editline")
+set_package_properties(Editline PROPERTIES TYPE OPTIONAL PURPOSE "Enables a better experience for the 'repl' command.")

--- a/cmake/FindReadline.cmake
+++ b/cmake/FindReadline.cmake
@@ -1,7 +1,0 @@
-include(FindDependency)
-
-find_dependency(Readline DISPLAY "readline" HEADERS "readline/readline.h" LIBRARIES "readline")
-
-include(FeatureSummary)
-set_package_properties(Readline PROPERTIES DESCRIPTION "A library for use by applications that allow users to edit command lines as they are typed in." URL "https://cnswww.cns.cwru.edu/php/chet/readline/rltop.html")
-set_package_properties(Readline PROPERTIES TYPE OPTIONAL PURPOSE "Enables a better experience for the 'repl' command.")

--- a/docker/puppetcpp-ci/Dockerfile
+++ b/docker/puppetcpp-ci/Dockerfile
@@ -1,6 +1,6 @@
 FROM gliderlabs/alpine:edge
 MAINTAINER Peter Huene <peterhuene@gmail.com>
-RUN apk add --no-cache make cmake gcc g++ boost-dev boost-program_options curl-dev readline-dev git py-pip && \
+RUN apk add --no-cache make cmake gcc g++ boost-dev boost-program_options curl-dev libedit-dev git py-pip && \
     pip install --user codecov && \
     git clone https://github.com/jbeder/yaml-cpp.git /tmp/yaml-cpp && \
     cd /tmp/yaml-cpp && \

--- a/docker/puppetcpp/Dockerfile
+++ b/docker/puppetcpp/Dockerfile
@@ -1,6 +1,6 @@
 FROM gliderlabs/alpine:edge
 MAINTAINER Peter Huene <peterhuene@gmail.com>
-RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev readline-dev git && \
+RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git && \
     git clone https://github.com/jbeder/yaml-cpp.git /tmp/yaml-cpp && \
     cd /tmp/yaml-cpp && \
     cmake . -DBUILD_SHARED_LIBS=ON && \
@@ -31,6 +31,6 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev readline-dev git &&
     cd && \
     rm -rf /tmp/puppetcpp && \
     mkdir -p /etc/puppetlabs/code/environments/production && \
-    apk --no-cache del make cmake gcc g++ boost-dev curl-dev readline-dev git && \
-    apk --no-cache add libstdc++ boost boost-program_options libcurl readline
+    apk --no-cache del make cmake gcc g++ boost-dev curl-dev libedit-dev git && \
+    apk --no-cache add libstdc++ boost boost-program_options libcurl libedit
 ENTRYPOINT ["/usr/bin/puppetcpp"]

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -8,7 +8,6 @@ include_directories(
     ${Facter_INCLUDE_DIRS}
     ${RAPIDJSON_INCLUDE_DIRS}
     ${UTF8CPP_INCLUDE_DIRS}
-    ${Readline_INCLUDE_DIR}
 )
 
 # Set common sources
@@ -189,8 +188,12 @@ target_link_libraries(puppet
     ${Boost_LIBRARIES}
     ${Facter_LIBRARY}
     ${YAMLCPP_LIBRARIES}
-    ${Readline_LIBRARY}
 )
+
+if (Editline_FOUND)
+    include_directories(puppet ${Editline_INCLUDE_DIR})
+    target_link_libraries(puppet ${Editline_LIBRARY})
+endif()
 
 install(TARGETS puppet DESTINATION lib)
 

--- a/lib/src/options/commands/repl.cc
+++ b/lib/src/options/commands/repl.cc
@@ -5,9 +5,8 @@
 #include <puppet/utility/filesystem/helpers.hpp>
 #include <boost/filesystem.hpp>
 
-#ifdef USE_Readline
-#include <readline/readline.h>
-#include <readline/history.h>
+#ifdef USE_Editline
+#include <editline/readline.h>
 #endif
 
 using namespace std;
@@ -24,7 +23,7 @@ static void output_result(puppet::runtime::values::value const& result)
     cout << " => " << result << endl;
 }
 
-#ifdef USE_Readline
+#ifdef USE_Editline
 static void repl_loop(evaluation::context& context)
 {
     auto history_file = home_directory();


### PR DESCRIPTION
Replacing references to the Readline library with the Editline library as the
latter has a compatible license.