### PR TITLE
(NPUP-41) Implement type inference and the `type` function.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -43,6 +43,7 @@ set(PUPPET_COMMON_SOURCES
     src/compiler/evaluation/functions/step.cc
     src/compiler/evaluation/functions/tag.cc
     src/compiler/evaluation/functions/tagged.cc
+    src/compiler/evaluation/functions/type.cc
     src/compiler/evaluation/functions/versioncmp.cc
     src/compiler/evaluation/functions/warning.cc
     src/compiler/evaluation/functions/with.cc

--- a/lib/include/puppet/compiler/evaluation/functions/type.hpp
+++ b/lib/include/puppet/compiler/evaluation/functions/type.hpp
@@ -1,0 +1,23 @@
+/**
+ * @file
+ * Declares the type function.
+ */
+#pragma once
+
+#include "descriptor.hpp"
+
+namespace puppet { namespace compiler { namespace evaluation { namespace functions {
+
+    /**
+     * Implements the type function.
+     */
+    struct type
+    {
+        /**
+         * Create a function descriptor.
+         * @return Returns the function descriptor representing this function.
+         */
+        static descriptor create_descriptor();
+    };
+
+}}}}  // puppet::compiler::evaluation::functions

--- a/lib/include/puppet/compiler/parser/rules.hpp
+++ b/lib/include/puppet/compiler/parser/rules.hpp
@@ -52,6 +52,7 @@ namespace puppet { namespace compiler { namespace parser {
     DECLARE_RULE(else_,                         "else",                          ast::else_)
     DECLARE_RULE(unless_expression,             "unless expression",             ast::unless_expression)
     DECLARE_RULE(function_call_expression,      "function call expression",      ast::function_call_expression)
+    DECLARE_RULE(function_name,                 "function name",                 ast::name)
     DECLARE_RULE(parameters,                    "parameters",                    std::vector<ast::parameter>)
     DECLARE_RULE(parameter,                     "parameter",                     ast::parameter)
     DECLARE_RULE(type_expression,               "type expression",               ast::postfix_expression)
@@ -224,7 +225,16 @@ namespace puppet { namespace compiler { namespace parser {
     )
     DEFINE_RULE(
         function_call_expression,
-        name >> (raw('(') > (raw(')', false) | expressions) > end(')') > -lambda_expression)
+        function_name >> (raw('(') > (raw(')', false) | expressions) > end(')') > -lambda_expression)
+    )
+    DEFINE_RULE(
+        function_name,
+        name |
+        (
+            (
+                begin(lexer::token_id::keyword_type, false)
+            ) > value > end() > tree
+        )
     )
     DEFINE_RULE(
         parameters,
@@ -638,7 +648,7 @@ namespace puppet { namespace compiler { namespace parser {
     // Type alias
     DEFINE_RULE(
         type_alias_expression,
-        begin(lexer::token_id::keyword_type) > type > raw('=') > type_expression
+        (begin(lexer::token_id::keyword_type) >> type) > raw('=') > type_expression
     )
 
     // These macros associate the above rules with their definitions
@@ -673,6 +683,7 @@ namespace puppet { namespace compiler { namespace parser {
         else_,
         unless_expression,
         function_call_expression,
+        function_name,
         parameters,
         parameter,
         type_expression,

--- a/lib/include/puppet/runtime/types/alias.hpp
+++ b/lib/include/puppet/runtime/types/alias.hpp
@@ -178,8 +178,19 @@ namespace puppet { namespace runtime { namespace types {
         map_type _map;
     };
 
+    /**
+     * Compares two recursion guard keys.
+     * @param left The left recursion guard key to compare.
+     * @param right The right recursion guard key to compare.
+     * @return Returns true if the two keys are equal or false if they are not equal.
+     */
     bool operator==(recursion_guard::key const& left, recursion_guard::key const& right);
-    size_t hash_value(recursion_guard::key const& key);
 
+    /**
+     * Hashes a recursion guard key.
+     * @param key The recursion guard key to hash.
+     * @return Returns the hash value.
+     */
+    size_t hash_value(recursion_guard::key const& key);
 
 }}}  // namespace puppet::runtime::types

--- a/lib/include/puppet/runtime/types/alias.hpp
+++ b/lib/include/puppet/runtime/types/alias.hpp
@@ -38,6 +38,12 @@ namespace puppet { namespace runtime { namespace types {
         values::type const& resolved_type() const;
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/any.hpp
+++ b/lib/include/puppet/runtime/types/any.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/array.hpp
+++ b/lib/include/puppet/runtime/types/array.hpp
@@ -77,6 +77,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/boolean.hpp
+++ b/lib/include/puppet/runtime/types/boolean.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/callable.hpp
+++ b/lib/include/puppet/runtime/types/callable.hpp
@@ -111,6 +111,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/catalog_entry.hpp
+++ b/lib/include/puppet/runtime/types/catalog_entry.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/class.hpp
+++ b/lib/include/puppet/runtime/types/class.hpp
@@ -42,6 +42,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/collection.hpp
+++ b/lib/include/puppet/runtime/types/collection.hpp
@@ -44,6 +44,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/data.hpp
+++ b/lib/include/puppet/runtime/types/data.hpp
@@ -45,6 +45,11 @@ namespace puppet { namespace runtime { namespace types {
          * @param expand True to specify that type aliases should be expanded or false if not.
          */
         void write(std::ostream& stream, bool expand = true) const;
+
+        /**
+         * Stores a default shared instance used internally by other Puppet types.
+         */
+        static data const instance;
     };
 
     /**

--- a/lib/include/puppet/runtime/types/data.hpp
+++ b/lib/include/puppet/runtime/types/data.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/defaulted.hpp
+++ b/lib/include/puppet/runtime/types/defaulted.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/enumeration.hpp
+++ b/lib/include/puppet/runtime/types/enumeration.hpp
@@ -37,6 +37,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/floating.hpp
+++ b/lib/include/puppet/runtime/types/floating.hpp
@@ -44,6 +44,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/hash.hpp
+++ b/lib/include/puppet/runtime/types/hash.hpp
@@ -88,6 +88,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/integer.hpp
+++ b/lib/include/puppet/runtime/types/integer.hpp
@@ -58,6 +58,12 @@ namespace puppet { namespace runtime { namespace types {
         void each(std::function<bool(int64_t, int64_t)> const& callback) const;
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/iterable.hpp
+++ b/lib/include/puppet/runtime/types/iterable.hpp
@@ -62,6 +62,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/iterator.hpp
+++ b/lib/include/puppet/runtime/types/iterator.hpp
@@ -62,6 +62,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/not_undef.hpp
+++ b/lib/include/puppet/runtime/types/not_undef.hpp
@@ -62,6 +62,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/numeric.hpp
+++ b/lib/include/puppet/runtime/types/numeric.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/optional.hpp
+++ b/lib/include/puppet/runtime/types/optional.hpp
@@ -62,6 +62,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/pattern.hpp
+++ b/lib/include/puppet/runtime/types/pattern.hpp
@@ -38,6 +38,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/regexp.hpp
+++ b/lib/include/puppet/runtime/types/regexp.hpp
@@ -36,6 +36,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/resource.hpp
+++ b/lib/include/puppet/runtime/types/resource.hpp
@@ -69,6 +69,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/runtime.hpp
+++ b/lib/include/puppet/runtime/types/runtime.hpp
@@ -73,6 +73,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/scalar.hpp
+++ b/lib/include/puppet/runtime/types/scalar.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/string.hpp
+++ b/lib/include/puppet/runtime/types/string.hpp
@@ -53,6 +53,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/struct.hpp
+++ b/lib/include/puppet/runtime/types/struct.hpp
@@ -68,6 +68,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/tuple.hpp
+++ b/lib/include/puppet/runtime/types/tuple.hpp
@@ -82,6 +82,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/type.hpp
+++ b/lib/include/puppet/runtime/types/type.hpp
@@ -62,6 +62,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/undef.hpp
+++ b/lib/include/puppet/runtime/types/undef.hpp
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/types/variant.hpp
+++ b/lib/include/puppet/runtime/types/variant.hpp
@@ -63,6 +63,20 @@ namespace puppet { namespace runtime { namespace types {
         static char const* name();
 
         /**
+         * Unwraps the variant.
+         * If the variant has only one type, that type is returned. Otherwise, this variant is moved into the return value.
+         * Note: because the
+         * @return Returns the unwraped type.
+         */
+        values::type unwrap();
+
+        /**
+         * Creates a generalized version of the type.
+         * @return Returns the generalized type.
+         */
+        values::type generalize() const;
+
+        /**
          * Determines if the given value is an instance of this type.
          * @param value The value to determine if it is an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/values/hash.hpp
+++ b/lib/include/puppet/runtime/values/hash.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "wrapper.hpp"
+#include "../../utility/indirect_collection.hpp"
 #include <boost/functional/hash.hpp>
 #include <ostream>
 #include <functional>
@@ -231,18 +232,8 @@ namespace puppet { namespace runtime { namespace values {
         bool erase(value const& key);
 
      private:
-        struct indirect_hasher
-        {
-            size_t operator()(values::value const* value) const;
-        };
-
-        struct indirect_comparer
-        {
-            bool operator()(values::value const* left, values::value const* right) const;
-        };
-
         sequence_type _elements;
-        std::unordered_map<value const*, iterator, indirect_hasher, indirect_comparer> _index;
+        utility::indirect_map<value, iterator> _index;
     };
 
     /**

--- a/lib/include/puppet/runtime/values/iterator.hpp
+++ b/lib/include/puppet/runtime/values/iterator.hpp
@@ -35,11 +35,18 @@ namespace puppet { namespace runtime { namespace values {
         explicit iterator(wrapper<values::value> value, int64_t step = 1, bool reverse = false);
 
         /**
-        * Gets the underlying iterable value.
-        * This never returns an iterator, only an underlying value.
-        * @return Returns the underlying iterable value.
-        */
+         * Gets the underlying iterable value.
+         * This never returns an iterator, only an underlying value.
+         * @return Returns the underlying iterable value.
+         */
         values::value const& value() const;
+
+        /**
+         * Infers the type for the produced values of the iterator.
+         * For example, Integer produces Integer, String produces String, Array[T] produces T, etc.
+         * @return Returns the inferred type.
+         */
+        values::type infer_produced_type() const;
 
         /**
          * Gets the iterator's step count.

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -35,6 +35,7 @@
 #include "../types/type.hpp"
 #include "../types/undef.hpp"
 #include "../types/variant.hpp"
+#include "../../utility/indirect_collection.hpp"
 #include "../../cast.hpp"
 #include <vector>
 #include <unordered_set>
@@ -368,18 +369,8 @@ namespace puppet { namespace runtime { namespace values {
         values::type const& operator[](size_t index) const;
 
      private:
-        struct indirect_hasher
-        {
-            size_t operator()(values::type const* type) const;
-        };
-
-        struct indirect_comparer
-        {
-            bool operator()(type const* right, type const* left) const;
-        };
-
         std::vector<type const*> _types;
-        std::unordered_set<type const*, indirect_hasher, indirect_comparer> _set;
+        utility::indirect_set<type> _set;
     };
 
     /**

--- a/lib/include/puppet/runtime/values/type.hpp
+++ b/lib/include/puppet/runtime/values/type.hpp
@@ -209,6 +209,13 @@ namespace puppet { namespace runtime { namespace values {
         type const& dereference() const;
 
         /**
+         * Creates a generalized version of the type.
+         * A new type is created that does not have type constraints.
+         * @return Returns the generalized type.
+         */
+        type generalize() const;
+
+        /**
          * Determines if the value is an instance of this type.
          * @param value The value to check if being an instance of this type.
          * @param guard The recursion guard to use for aliases.

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -289,9 +289,10 @@ namespace puppet { namespace runtime { namespace values {
 
         /**
          * Infers the type of the value.
+         * @param detailed True to do a detailed inference or false to do a reduced inference.
          * @return Returns the runtime type of the value.
          */
-        values::type infer_type() const;
+        values::type infer_type(bool detailed = false) const;
 
         /**
          * Converts the value to an array; the value is returned as an array if already an array.

--- a/lib/include/puppet/runtime/values/value.hpp
+++ b/lib/include/puppet/runtime/values/value.hpp
@@ -288,10 +288,10 @@ namespace puppet { namespace runtime { namespace values {
         bool is_truthy() const;
 
         /**
-         * Gets the type of the value.
+         * Infers the type of the value.
          * @return Returns the runtime type of the value.
          */
-        values::type get_type() const;
+        values::type infer_type() const;
 
         /**
          * Converts the value to an array; the value is returned as an array if already an array.

--- a/lib/include/puppet/utility/indirect_collection.hpp
+++ b/lib/include/puppet/utility/indirect_collection.hpp
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * Declares the indirect set.
+ */
+#pragma once
+
+#include <unordered_set>
+#include <unordered_map>
+#include <boost/functional/hash.hpp>
+
+namespace puppet { namespace utility {
+
+    /**
+     * Utility type for indirectly hashing values.
+     * @tparam T The value type.
+     */
+    template <typename T>
+    struct indirect_hasher
+    {
+        /**
+         * Called to hash a value.
+         * @param value The value to hash.
+         * @return Returns the hash value.
+         */
+        size_t operator()(T const* value) const
+        {
+            boost::hash<T> hasher;
+            return hasher(*value);
+        }
+    };
+
+    /**
+     * Utility type for indirectly comparing values.
+     * @tparam T The value type.
+     */
+    template <typename T>
+    struct indirect_comparer
+    {
+        /**
+         * Called to compare two values.
+         * @param left The left value to compare.
+         * @param right The right value to compare.
+         * @return Returns true if the two values are equal or false if they are not equal.
+         */
+        bool operator()(T const* left, T const* right) const
+        {
+            return *left == *right;
+        }
+    };
+
+    /**
+     * An indirect, unordered map.
+     * @tparam KeyType The key type for the map.
+     * @tparam ValueType The value type for the map.
+     */
+    template <typename KeyType, typename ValueType>
+    using indirect_map = std::unordered_map<KeyType const*, ValueType, indirect_hasher<KeyType>, indirect_comparer<KeyType>>;
+
+    /**
+     * An indirect, unordered set.
+     * @tparam ValueType The value type for the set.
+     */
+    template <typename ValueType>
+    using indirect_set = std::unordered_set<ValueType const*, indirect_hasher<ValueType>, indirect_comparer<ValueType>>;
+
+}}  // puppet::utility

--- a/lib/src/compiler/evaluation/access_evaluator.cc
+++ b/lib/src/compiler/evaluation/access_evaluator.cc
@@ -59,7 +59,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for start index but found %2%.") %
                      integer::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -80,7 +80,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected %1% for count but found %2%.") %
                          integer::name() %
-                         _arguments[1]->get_type()
+                         _arguments[1]->infer_type()
                         ).str(),
                         _contexts[1],
                         _context.backtrace()
@@ -135,7 +135,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for start index but found %2%.") %
                      integer::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -156,7 +156,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected %1% for count but found %2%.") %
                          integer::name() %
-                         _arguments[1]->get_type()
+                         _arguments[1]->infer_type()
                         ).str(),
                         _contexts[1],
                         _context.backtrace()
@@ -258,7 +258,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -286,7 +286,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -358,7 +358,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                         (boost::format("expected parameter to be %1% or %2% but found %3%.") %
                          types::string::name() %
                          regexp::name() %
-                         _arguments[0]->get_type()
+                         _arguments[0]->infer_type()
                         ).str(),
                         _contexts[0],
                         _context.backtrace()
@@ -380,7 +380,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected %1% but found %2%.") %
                          types::string::name() %
-                         _arguments[i]->get_type()
+                         _arguments[i]->infer_type()
                         ).str(),
                         _contexts[i],
                         _context.backtrace()
@@ -429,7 +429,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                      types::string::name() %
                      regexp::name() %
                      pattern::name() %
-                     _arguments[i]->get_type()
+                     _arguments[i]->infer_type()
                     ).str(),
                     _contexts[i],
                     _context.backtrace()
@@ -457,7 +457,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -499,7 +499,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -511,7 +511,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[1]->get_type()
+                     _arguments[1]->infer_type()
                     ).str(),
                     _contexts[1],
                     _context.backtrace()
@@ -560,7 +560,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for first argument but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -616,7 +616,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 (boost::format("expected parameter to be %1% or %2% but found %3%.") %
                  types::type::name() %
                  types::string::name() %
-                 _arguments[0]->get_type()
+                 _arguments[0]->infer_type()
                 ).str(),
                 _contexts[0],
                 _context.backtrace()
@@ -651,7 +651,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 (boost::format("expected parameter to be %1% or %2% but found %3%.") %
                  types::type::name() %
                  types::string::name() %
-                 _arguments[0]->get_type()
+                 _arguments[0]->infer_type()
                 ).str(),
                 _contexts[0],
                 _context.backtrace()
@@ -677,7 +677,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::type::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -706,7 +706,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::hash::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -746,7 +746,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                          types::string::name() %
                          types::optional::name() %
                          types::not_undef::name() %
-                         kvp.key().get_type()
+                         kvp.key().infer_type()
                         ).str(),
                         _contexts[0],
                         _context.backtrace()
@@ -758,7 +758,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected hash values to be %1% but found %2%.") %
                          types::type::name() %
-                         kvp.value().get_type()
+                         kvp.value().infer_type()
                         ).str(),
                         _contexts[0],
                         _context.backtrace()
@@ -779,7 +779,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected parameter to be %1% but found %2%.") %
                          types::type::name() %
-                         _arguments[i]->get_type()
+                         _arguments[i]->infer_type()
                         ).str(),
                         _contexts[i],
                         _context.backtrace()
@@ -815,7 +815,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     (boost::format("expected parameter to be %1% or typed %2% but found %3%.") %
                      types::string::name() %
                      types::resource::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -914,7 +914,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                                 (boost::format("expected %1% or %2%[%1%] for last argument but found %3%.") %
                                  types::callable::name() %
                                  types::optional::name() %
-                                 _arguments[i + 2]->get_type()
+                                 _arguments[i + 2]->infer_type()
                                 ).str(),
                                 _contexts[i + 2],
                                 _context.backtrace()
@@ -947,7 +947,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::string::name() %
-                     _arguments[0]->get_type()
+                     _arguments[0]->infer_type()
                     ).str(),
                     _contexts[0],
                     _context.backtrace()
@@ -962,7 +962,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected parameter to be %1% but found %2%.") %
                          types::string::name() %
-                         _arguments[1]->get_type()
+                         _arguments[1]->infer_type()
                         ).str(),
                         _contexts[1],
                         _context.backtrace()
@@ -978,7 +978,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         {
             throw evaluation_exception(
                 (boost::format("access expression is not supported for %1%.") %
-                 value(target).get_type()
+                 value(target).infer_type()
                 ).str(),
                 _expression,
                 _context.backtrace()
@@ -1026,7 +1026,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                         throw evaluation_exception(
                             (boost::format("expected parameter to be %1% but found %2%.") %
                              Type::name() %
-                             argument->get_type()
+                             argument->infer_type()
                             ).str(),
                             _contexts[start_index],
                             _context.backtrace()
@@ -1049,7 +1049,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                         throw evaluation_exception(
                             (boost::format("expected parameter to be %1% but found %2%.") %
                              Type::name() %
-                             argument->get_type()
+                             argument->infer_type()
                             ).str(),
                             _contexts[start_index + 1],
                             _context.backtrace()
@@ -1083,7 +1083,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for resource title but found %2%.") %
                      types::string::name() %
-                     argument.get_type()
+                     argument.infer_type()
                     ).str(),
                     context,
                     _context.backtrace()
@@ -1104,7 +1104,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for class title but found %2%.") %
                      types::string::name() %
-                     argument.get_type()
+                     argument.infer_type()
                     ).str(),
                     context,
                     _context.backtrace()
@@ -1147,7 +1147,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected parameter to be %1% but found %2%.") %
                      types::string::name() %
-                     _arguments[index]->get_type()
+                     _arguments[index]->infer_type()
                     ).str(),
                     _contexts[index],
                     _context.backtrace()

--- a/lib/src/compiler/evaluation/context.cc
+++ b/lib/src/compiler/evaluation/context.cc
@@ -582,7 +582,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% for 'stage' metaparameter but found %2%.") %
                      types::string::name() %
-                     attribute->value().get_type()
+                     attribute->value().infer_type()
                     ).str(),
                     attribute->value_context(),
                     backtrace()

--- a/lib/src/compiler/evaluation/dispatcher.cc
+++ b/lib/src/compiler/evaluation/dispatcher.cc
@@ -24,6 +24,7 @@
 #include <puppet/compiler/evaluation/functions/step.hpp>
 #include <puppet/compiler/evaluation/functions/tag.hpp>
 #include <puppet/compiler/evaluation/functions/tagged.hpp>
+#include <puppet/compiler/evaluation/functions/type.hpp>
 #include <puppet/compiler/evaluation/functions/versioncmp.hpp>
 #include <puppet/compiler/evaluation/functions/warning.hpp>
 #include <puppet/compiler/evaluation/functions/with.hpp>
@@ -91,6 +92,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         add(functions::step::create_descriptor());
         add(functions::tag::create_descriptor());
         add(functions::tagged::create_descriptor());
+        add(functions::type::create_descriptor());
         add(functions::versioncmp::create_descriptor());
         add(functions::warning::create_descriptor());
         add(functions::with::create_descriptor());

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -1445,7 +1445,7 @@ namespace puppet { namespace compiler { namespace evaluation {
 
             // Verify the value matches the parameter type
             validate_parameter_type(_context, parameter, *value, [&](std::string message) {
-                throw evaluation_exception(rvalue_cast(message), parameter.default_value->context(), _context.backtrace());
+                throw evaluation_exception(rvalue_cast(message), context, _context.backtrace());
             });
 
             // Set the parameter in the scope

--- a/lib/src/compiler/evaluation/evaluator.cc
+++ b/lib/src/compiler/evaluation/evaluator.cc
@@ -384,7 +384,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 (boost::format("expected %1% or qualified %2% for resource type but found %3%.") %
                     types::string::name() %
                     types::resource::name() %
-                    type_value.get_type()
+                    type_value.infer_type()
                 ).str(),
                 expression.type.context(),
                 _context.backtrace()
@@ -436,7 +436,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected qualified %1% but found %2%.") %
                      types::resource::name() %
-                     value(type).get_type()
+                     value(type).infer_type()
                     ).str(),
                     resource_context,
                     context.backtrace()
@@ -473,7 +473,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                     throw evaluation_exception(
                         (boost::format("expected qualified %1% for array element but found %2%.") %
                          types::resource::name() %
-                         element->get_type()
+                         element->infer_type()
                         ).str(),
                         context,
                         _context.backtrace()
@@ -503,7 +503,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             throw evaluation_exception(
                 (boost::format("expected qualified %1% for resource reference but found %2%.") %
                  types::resource::name() %
-                 reference.get_type()
+                 reference.infer_type()
                 ).str(),
                 context,
                 _context.backtrace()
@@ -521,7 +521,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             throw evaluation_exception(
                 (boost::format("expected %1% type but found %2%.") %
                  types::resource::name() %
-                 value.get_type()
+                 value.infer_type()
                 ).str(),
                 expression.type,
                 _context.backtrace()
@@ -534,7 +534,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             throw evaluation_exception(
                 (boost::format("expected %1% type but found %2%.") %
                  types::resource::name() %
-                 value.get_type()
+                 value.infer_type()
                 ).str(),
                 expression.type,
                 _context.backtrace()
@@ -548,7 +548,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected %1% type but found %2%.") %
                      types::resource::name() %
-                     value.get_type()
+                     value.infer_type()
                     ).str(),
                     expression.type,
                     _context.backtrace()
@@ -753,7 +753,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             throw evaluation_exception(
                 (boost::format("expected a %1% but found %2%.") %
                  types::hash::name() %
-                 value.get_type()
+                 value.infer_type()
                 ).str(),
                 context,
                 _context.backtrace()
@@ -768,7 +768,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw evaluation_exception(
                     (boost::format("expected all keys in hash to be %1% but found %2%.") %
                      types::string::name() %
-                     kvp.key().get_type()
+                     kvp.key().infer_type()
                     ).str(),
                     context,
                     _context.backtrace()
@@ -858,7 +858,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 (boost::format("expected %1% for attribute '%2%' but found %3%.") %
                  *type %
                  name %
-                 (original ? original->get_type() : value.get_type())
+                 (original ? original->infer_type() : value.infer_type())
                 ).str(),
                 context,
                 _context.backtrace()
@@ -1079,7 +1079,7 @@ namespace puppet { namespace compiler { namespace evaluation {
             throw evaluation_exception(
                 (boost::format("expected %1% for parameter type but found %2%.") %
                  types::type::name() %
-                 result.get_type()
+                 result.infer_type()
                 ).str(),
                 parameter.type->context(),
                 context.backtrace()
@@ -1087,7 +1087,7 @@ namespace puppet { namespace compiler { namespace evaluation {
         }
         types::recursion_guard guard;
         if (!type->is_instance(value, guard)) {
-            error((boost::format("parameter $%1% has expected type %2% but was given %3%.") % parameter.variable.name % *type % value.get_type()).str());
+            error((boost::format("parameter $%1% has expected type %2% but was given %3%.") % parameter.variable.name % *type % value.infer_type()).str());
         }
     }
 
@@ -1303,7 +1303,7 @@ namespace puppet { namespace compiler { namespace evaluation {
                 throw argument_exception(
                     (boost::format("expected %1% for argument key but found %2%.") %
                      types::string::name() %
-                     kvp.key().get_type()
+                     kvp.key().infer_type()
                     ).str(),
                     index
                 );

--- a/lib/src/compiler/evaluation/functions/assert_type.cc
+++ b/lib/src/compiler/evaluation/functions/assert_type.cc
@@ -22,7 +22,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             throw evaluation_exception(
                 (boost::format("type assertion failure: expected %1% but found %2%.") %
                  type %
-                 instance.get_type()
+                 instance.infer_type()
                 ).str(),
                 context.argument_context(1),
                 context.context().backtrace()
@@ -30,7 +30,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
         }
 
         // Call the block and give it the type of the argument as the second argument
-        instance = instance.get_type();
+        instance = instance.infer_type();
         return context.yield(context.arguments());
     }
 

--- a/lib/src/compiler/evaluation/functions/defined.cc
+++ b/lib/src/compiler/evaluation/functions/defined.cc
@@ -92,7 +92,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             (boost::format("expected %1% or %2% for type parameter but found %3%.") %
              types::resource::name() %
              types::klass::name() %
-             values::value(*argument.parameter()).get_type()
+             values::value(*argument.parameter()).infer_type()
             ).str(),
             argument_context,
             context.backtrace()
@@ -115,7 +115,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
              types::resource::name() %
              types::klass::name() %
              types::type::name() %
-             values::value(argument).get_type()
+             values::value(argument).infer_type()
             ).str(),
             argument_context,
             context.backtrace()
@@ -135,7 +135,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             (boost::format("expected %1% or %2% but found %3%.") %
              types::string::name() %
              types::type::name() %
-             argument.get_type()
+             argument.infer_type()
             ).str(),
             argument_context,
             context.backtrace()

--- a/lib/src/compiler/evaluation/functions/descriptor.cc
+++ b/lib/src/compiler/evaluation/functions/descriptor.cc
@@ -303,7 +303,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             (boost::format("function '%1%' expects %2% but was given %3%.") %
              _name %
              set %
-             context.argument(min_argument_mismatch).get_type()
+             context.argument(min_argument_mismatch).infer_type()
             ).str(),
             context.argument_context(min_argument_mismatch),
             evaluation_context.backtrace()

--- a/lib/src/compiler/evaluation/functions/include.cc
+++ b/lib/src/compiler/evaluation/functions/include.cc
@@ -58,7 +58,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                 return;
             }
         }
-        throw evaluation_exception((boost::format("cannot declare class with argument type %1%.") % name.get_type()).str(), declaration_context, context.backtrace());
+        throw evaluation_exception((boost::format("cannot declare class with argument type %1%.") % name.infer_type()).str(), declaration_context, context.backtrace());
     }
 
     void declare_class(call_context& context, boost::optional<compiler::relationship> relationship = boost::none)

--- a/lib/src/compiler/evaluation/functions/realize.cc
+++ b/lib/src/compiler/evaluation/functions/realize.cc
@@ -58,7 +58,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
              types::string::name() %
              types::array::name() %
              types::resource::name() %
-             argument.get_type()
+             argument.infer_type()
             ).str(),
             argument_context,
             context.backtrace()

--- a/lib/src/compiler/evaluation/functions/tag.cc
+++ b/lib/src/compiler/evaluation/functions/tag.cc
@@ -39,7 +39,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                         (boost::format("expected %1% or %2%[%1%] of %1% but found %3%.") %
                          types::string::name() %
                          types::array::name() %
-                         argument.get_type()
+                         argument.infer_type()
                         ).str(),
                         context.argument_context(i),
                         evaluation_context.backtrace()

--- a/lib/src/compiler/evaluation/functions/tagged.cc
+++ b/lib/src/compiler/evaluation/functions/tagged.cc
@@ -41,7 +41,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                     throw evaluation_exception(
                         (boost::format("expected %1% or array of %1% but found %2%.") %
                          types::string::name() %
-                         argument.get_type()
+                         argument.infer_type()
                         ).str(),
                         context.argument_context(i),
                         evaluation_context.backtrace()

--- a/lib/src/compiler/evaluation/functions/type.cc
+++ b/lib/src/compiler/evaluation/functions/type.cc
@@ -1,0 +1,37 @@
+#include <puppet/compiler/evaluation/functions/type.hpp>
+#include <puppet/compiler/evaluation/functions/call_context.hpp>
+
+using namespace std;
+using namespace puppet::runtime;
+
+namespace puppet { namespace compiler { namespace evaluation { namespace functions {
+
+    descriptor type::create_descriptor()
+    {
+        functions::descriptor descriptor{ "type" };
+
+        descriptor.add("Callable[Any, String, 1, 2]", [](call_context& context) -> values::value {
+            if (context.arguments().size() == 2) {
+                auto& method = context.argument(1).require<string>();
+                if (method == "reduced") {
+                    return context.argument(0).infer_type();
+                }
+                if (method == "generalized") {
+                    return context.argument(0).infer_type().generalize();
+                }
+                if (method != "detailed") {
+                    throw evaluation_exception(
+                        (boost::format("'%1%' is not a valid type inference method: expected 'generalized', 'reduced', or 'detailed'.") %
+                         method
+                        ).str(),
+                        context.argument_context(1),
+                        context.context().backtrace()
+                    );
+                }
+            }
+            return context.argument(0).infer_type(true);
+        });
+        return descriptor;
+    }
+
+}}}}  // namespace puppet::compiler::evaluation::functions

--- a/lib/src/compiler/evaluation/operators/binary/assignment.cc
+++ b/lib/src/compiler/evaluation/operators/binary/assignment.cc
@@ -24,7 +24,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             if (!var) {
                 throw evaluation_exception(
                     (boost::format("cannot assign to %1%: assignment can only be performed on variables.") %
-                     left.get_type()
+                     left.infer_type()
                     ).str(),
                     left_context,
                     evaluation_context.backtrace()

--- a/lib/src/compiler/evaluation/operators/binary/descriptor.cc
+++ b/lib/src/compiler/evaluation/operators/binary/descriptor.cc
@@ -112,7 +112,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             (boost::format("binary operator '%1%' expects %2% but was given %3%.") %
              _operator %
              set %
-             (!rhs_match ? context.right() : context.left()).get_type()
+             (!rhs_match ? context.right() : context.left()).infer_type()
             ).str(),
             !rhs_match ? context.right_context() : context.left_context(),
             evaluation_context.backtrace()

--- a/lib/src/compiler/evaluation/operators/unary/descriptor.cc
+++ b/lib/src/compiler/evaluation/operators/unary/descriptor.cc
@@ -69,7 +69,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace operato
             (boost::format("unary operator '%1%' expects %2% but was given %3%.") %
              _operator %
              set %
-             context.operand().get_type()
+             context.operand().infer_type()
             ).str(),
             context.operand_context(),
             evaluation_context.backtrace()

--- a/lib/src/runtime/types/alias.cc
+++ b/lib/src/runtime/types/alias.cc
@@ -24,6 +24,12 @@ namespace puppet { namespace runtime { namespace types {
         return *_resolved_type;
     }
 
+    values::type alias::generalize() const
+    {
+        // Aliases don't generalize the resolved type; they generalize to themselves
+        return *this;
+    }
+
     bool alias::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto result = guard.add(*this, &value);

--- a/lib/src/runtime/types/any.cc
+++ b/lib/src/runtime/types/any.cc
@@ -10,6 +10,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Any";
     }
 
+    values::type any::generalize() const
+    {
+        return *this;
+    }
+
     bool any::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // All values are an instance of Any

--- a/lib/src/runtime/types/array.cc
+++ b/lib/src/runtime/types/array.cc
@@ -109,15 +109,29 @@ namespace puppet { namespace runtime { namespace types {
 
     void array::write(ostream& stream, bool expand) const
     {
-        stream << array::name() << '[';
-        _element_type->write(stream, false);
-        bool from_default = _from == 0;
-        bool to_default = _to == numeric_limits<int64_t>::max();
-        if (from_default && to_default) {
-            // Only output the type
-            stream << ']';
+        stream << array::name();
+
+        // Write empty arrays in a special format, without the element type
+        if (_from == 0 && _to == 0) {
+            stream << "[0, 0]";
             return;
         }
+
+        bool from_default = _from == 0;
+        bool to_default = _to == numeric_limits<int64_t>::max();
+
+        if (from_default && to_default) {
+            // Only output the type, provided it is not default
+            if (*_element_type != data::instance) {
+                stream << '[';
+                _element_type->write(stream, false);
+                stream << ']';
+            }
+            return;
+        }
+
+        stream << '[';
+        _element_type->write(stream, false);
         stream << ", ";
         if (from_default) {
             stream << "default";

--- a/lib/src/runtime/types/array.cc
+++ b/lib/src/runtime/types/array.cc
@@ -53,6 +53,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Array";
     }
 
+    values::type array::generalize() const
+    {
+        return types::array{ make_unique<values::type>(_element_type->generalize()) };
+    }
+
     bool array::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for array

--- a/lib/src/runtime/types/boolean.cc
+++ b/lib/src/runtime/types/boolean.cc
@@ -12,6 +12,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Boolean";
     }
 
+    values::type boolean::generalize() const
+    {
+        return *this;
+    }
+
     bool boolean::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.as<bool>();

--- a/lib/src/runtime/types/callable.cc
+++ b/lib/src/runtime/types/callable.cc
@@ -87,6 +87,21 @@ namespace puppet { namespace runtime { namespace types {
         return "Callable";
     }
 
+    values::type callable::generalize() const
+    {
+        vector<unique_ptr<values::type>> types;
+        for (auto& type : _types) {
+            types.emplace_back(make_unique<values::type>(type->generalize()));
+        }
+        auto size = static_cast<int64_t>(_types.size());
+        return types::callable{
+            rvalue_cast(types),
+            size,
+            size,
+            _block_type ? make_unique<values::type>(_block_type->generalize()) : nullptr
+        };
+    }
+
     bool callable::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Currently functions cannot be represented as a value.

--- a/lib/src/runtime/types/catalog_entry.cc
+++ b/lib/src/runtime/types/catalog_entry.cc
@@ -11,6 +11,11 @@ namespace puppet { namespace runtime { namespace types {
         return "CatalogEntry";
     }
 
+    values::type catalog_entry::generalize() const
+    {
+        return *this;
+    }
+
     bool catalog_entry::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return resource::instance.is_instance(value, guard) || klass::instance.is_instance(value, guard);

--- a/lib/src/runtime/types/class.cc
+++ b/lib/src/runtime/types/class.cc
@@ -30,6 +30,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Class";
     }
 
+    values::type klass::generalize() const
+    {
+        return *this;
+    }
+
     bool klass::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<values::type>();

--- a/lib/src/runtime/types/collection.cc
+++ b/lib/src/runtime/types/collection.cc
@@ -26,6 +26,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Collection";
     }
 
+    values::type collection::generalize() const
+    {
+        return types::collection{};
+    }
+
     bool collection::is_instance(values::value const& value, recursion_guard& guard) const
     {
         int64_t size = 0;

--- a/lib/src/runtime/types/data.cc
+++ b/lib/src/runtime/types/data.cc
@@ -7,6 +7,11 @@ namespace puppet { namespace runtime { namespace types {
 
     data const data::instance{};
 
+    values::type data::generalize() const
+    {
+        return *this;
+    }
+
     bool data::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return scalar::instance.is_instance(value, guard) || array::instance.is_instance(value, guard) ||

--- a/lib/src/runtime/types/data.cc
+++ b/lib/src/runtime/types/data.cc
@@ -5,6 +5,8 @@ using namespace std;
 
 namespace puppet { namespace runtime { namespace types {
 
+    data const data::instance{};
+
     bool data::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return scalar::instance.is_instance(value, guard) || array::instance.is_instance(value, guard) ||

--- a/lib/src/runtime/types/defaulted.cc
+++ b/lib/src/runtime/types/defaulted.cc
@@ -10,6 +10,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Default";
     }
 
+    values::type defaulted::generalize() const
+    {
+        return *this;
+    }
+
     bool defaulted::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.is_default();

--- a/lib/src/runtime/types/enumeration.cc
+++ b/lib/src/runtime/types/enumeration.cc
@@ -21,6 +21,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Enum";
     }
 
+    values::type enumeration::generalize() const
+    {
+        return *this;
+    }
+
     bool enumeration::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<std::string>();

--- a/lib/src/runtime/types/floating.cc
+++ b/lib/src/runtime/types/floating.cc
@@ -28,6 +28,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Float";
     }
 
+    values::type floating::generalize() const
+    {
+        return types::floating{};
+    }
+
     bool floating::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<double>();

--- a/lib/src/runtime/types/hash.cc
+++ b/lib/src/runtime/types/hash.cc
@@ -67,6 +67,14 @@ namespace puppet { namespace runtime { namespace types {
         return "Hash";
     }
 
+    values::type hash::generalize() const
+    {
+        return types::hash{
+            make_unique<values::type>(_key_type->generalize()),
+            make_unique<values::type>(_value_type->generalize())
+        };
+    }
+
     bool hash::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for hash

--- a/lib/src/runtime/types/hash.cc
+++ b/lib/src/runtime/types/hash.cc
@@ -121,17 +121,32 @@ namespace puppet { namespace runtime { namespace types {
 
     void hash::write(ostream& stream, bool expand) const
     {
-        stream << hash::name() << '[';
+        stream << hash::name();
+
+        // Write empty hashes in a special format, without the key and value types
+        if (_from == 0 && _to == 0) {
+            stream << "[0, 0]";
+            return;
+        }
+
+        bool from_default = _from == 0;
+        bool to_default = _to == numeric_limits<int64_t>::max();
+
+        if (from_default && to_default) {
+            if (*_key_type != scalar::instance || *_value_type != data::instance) {
+                stream << '[';
+                _key_type->write(stream, false);
+                stream << ", ";
+                _value_type->write(stream, false);
+                stream << ']';
+            }
+            return;
+        }
+
+        stream << '[';
         _key_type->write(stream, false);
         stream << ", ";
         _value_type->write(stream, false);
-        bool from_default = _from == 0;
-        bool to_default = _to == numeric_limits<int64_t>::max();
-        if (from_default && to_default) {
-            // Only output the types
-            stream << ']';
-            return;
-        }
         stream << ", ";
         if (from_default) {
             stream << "default";

--- a/lib/src/runtime/types/integer.cc
+++ b/lib/src/runtime/types/integer.cc
@@ -51,6 +51,11 @@ namespace puppet { namespace runtime { namespace types {
         }
     }
 
+    values::type integer::generalize() const
+    {
+        return types::integer{};
+    }
+
     bool integer::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<int64_t>();

--- a/lib/src/runtime/types/iterable.cc
+++ b/lib/src/runtime/types/iterable.cc
@@ -31,6 +31,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Iterable";
     }
 
+    values::type iterable::generalize() const
+    {
+        return types::iterable{ _type ? make_unique<values::type>(_type->generalize()) : nullptr };
+    }
+
     bool iterable::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for string

--- a/lib/src/runtime/types/iterator.cc
+++ b/lib/src/runtime/types/iterator.cc
@@ -31,6 +31,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Iterator";
     }
 
+    values::type iterator::generalize() const
+    {
+        return types::iterator{ _type ? make_unique<values::type>(_type->generalize()) : nullptr };
+    }
+
     bool iterator::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto iterator = value.as<values::iterator>();

--- a/lib/src/runtime/types/not_undef.cc
+++ b/lib/src/runtime/types/not_undef.cc
@@ -32,6 +32,11 @@ namespace puppet { namespace runtime { namespace types {
         return "NotUndef";
     }
 
+    values::type not_undef::generalize() const
+    {
+        return types::not_undef{ _type ? make_unique<values::type>(_type->generalize()) : nullptr };
+    }
+
     bool not_undef::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Undef never matches

--- a/lib/src/runtime/types/numeric.cc
+++ b/lib/src/runtime/types/numeric.cc
@@ -12,6 +12,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Numeric";
     }
 
+    values::type numeric::generalize() const
+    {
+        return *this;
+    }
+
     bool numeric::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return integer::instance.is_instance(value, guard) || floating::instance.is_instance(value, guard);

--- a/lib/src/runtime/types/optional.cc
+++ b/lib/src/runtime/types/optional.cc
@@ -32,6 +32,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Optional";
     }
 
+    values::type optional::generalize() const
+    {
+        return types::optional{ _type ? make_unique<values::type>(_type->generalize()) : nullptr };
+    }
+
     bool optional::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Undef always matches

--- a/lib/src/runtime/types/pattern.cc
+++ b/lib/src/runtime/types/pattern.cc
@@ -21,6 +21,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Pattern";
     }
 
+    values::type pattern::generalize() const
+    {
+        return *this;
+    }
+
     bool pattern::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for string

--- a/lib/src/runtime/types/regexp.cc
+++ b/lib/src/runtime/types/regexp.cc
@@ -23,6 +23,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Regexp";
     }
 
+    values::type regexp::generalize() const
+    {
+        return *this;
+    }
+
     bool regexp::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<values::regex>();

--- a/lib/src/runtime/types/resource.cc
+++ b/lib/src/runtime/types/resource.cc
@@ -117,6 +117,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Resource";
     }
 
+    values::type resource::generalize() const
+    {
+        return *this;
+    }
+
     bool resource::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for type

--- a/lib/src/runtime/types/runtime.cc
+++ b/lib/src/runtime/types/runtime.cc
@@ -49,6 +49,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Runtime";
     }
 
+    values::type runtime::generalize() const
+    {
+        return *this;
+    }
+
     bool runtime::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for type

--- a/lib/src/runtime/types/scalar.cc
+++ b/lib/src/runtime/types/scalar.cc
@@ -12,6 +12,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Scalar";
     }
 
+    values::type scalar::generalize() const
+    {
+        return *this;
+    }
+
     bool scalar::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return numeric::instance.is_instance(value, guard) || string::instance.is_instance(value, guard) ||

--- a/lib/src/runtime/types/string.cc
+++ b/lib/src/runtime/types/string.cc
@@ -35,6 +35,11 @@ namespace puppet { namespace runtime { namespace types {
         return "String";
     }
 
+    values::type string::generalize() const
+    {
+        return types::string{};
+    }
+
     bool string::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<std::string>();

--- a/lib/src/runtime/types/struct.cc
+++ b/lib/src/runtime/types/struct.cc
@@ -145,7 +145,7 @@ namespace puppet { namespace runtime { namespace types {
         if (_schema.empty()) {
             return;
         }
-        stream << "[";
+        stream << "[{";
         bool first = true;
         for (auto const& kvp : _schema) {
             if (first) {
@@ -153,11 +153,15 @@ namespace puppet { namespace runtime { namespace types {
             } else {
                 stream << ", ";
             }
-            kvp.first->write(stream, false);
+            if (boost::get<enumeration>(kvp.first.get())) {
+                stream << to_key(*kvp.first);
+            } else {
+                kvp.first->write(stream, false);
+            }
             stream << " => ";
             kvp.second->write(stream, false);
         }
-        stream << "]";
+        stream << "}]";
     }
 
     std::string const& structure::to_key(values::type const& type)

--- a/lib/src/runtime/types/struct.cc
+++ b/lib/src/runtime/types/struct.cc
@@ -51,6 +51,15 @@ namespace puppet { namespace runtime { namespace types {
         return "Struct";
     }
 
+    values::type structure::generalize() const
+    {
+        schema_type schema;
+        for (auto& kvp : _schema) {
+            schema.emplace_back(make_unique<values::type>(kvp.first->generalize()), make_unique<values::type>(kvp.second->generalize()));
+        }
+        return types::structure{ rvalue_cast(schema) };
+    }
+
     bool structure::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for hash

--- a/lib/src/runtime/types/tuple.cc
+++ b/lib/src/runtime/types/tuple.cc
@@ -61,6 +61,16 @@ namespace puppet { namespace runtime { namespace types {
         return "Tuple";
     }
 
+    values::type tuple::generalize() const
+    {
+        vector<unique_ptr<values::type>> types;
+        for (auto& type : _types) {
+            types.emplace_back(make_unique<values::type>(type->generalize()));
+        }
+        // A Tuple does not modify the from/to like other types
+        return types::tuple{ rvalue_cast(types), _from, _to };
+    }
+
     bool tuple::is_instance(values::value const& value, recursion_guard& guard) const
     {
         // Check for array

--- a/lib/src/runtime/types/type.cc
+++ b/lib/src/runtime/types/type.cc
@@ -32,6 +32,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Type";
     }
 
+    values::type type::generalize() const
+    {
+        return types::type{ _parameter ? make_unique<values::type>(_parameter->generalize()) : nullptr };
+    }
+
     bool type::is_instance(values::value const& value, recursion_guard& guard) const
     {
         auto ptr = value.as<values::type>();

--- a/lib/src/runtime/types/type.cc
+++ b/lib/src/runtime/types/type.cc
@@ -79,7 +79,9 @@ namespace puppet { namespace runtime { namespace types {
     {
         if (!left.parameter() && !right.parameter()) {
             return true;
-        } else if (left.parameter() || right.parameter()) {
+        } else if (!left.parameter()) {
+            return false;
+        } else if (!right.parameter()) {
             return false;
         }
         return *left.parameter() == *right.parameter();

--- a/lib/src/runtime/types/undef.cc
+++ b/lib/src/runtime/types/undef.cc
@@ -12,6 +12,11 @@ namespace puppet { namespace runtime { namespace types {
         return "Undef";
     }
 
+    values::type undef::generalize() const
+    {
+        return *this;
+    }
+
     bool undef::is_instance(values::value const& value, recursion_guard& guard) const
     {
         return value.is_undef();

--- a/lib/src/runtime/values/hash.cc
+++ b/lib/src/runtime/values/hash.cc
@@ -158,16 +158,6 @@ namespace puppet { namespace runtime { namespace values {
         return true;
     }
 
-    size_t hash::indirect_hasher::operator()(values::value const* value) const
-    {
-        return hash_value(*value);
-    }
-
-    bool hash::indirect_comparer::operator()(values::value const* left, values::value const* right) const
-    {
-        return *left == *right;
-    }
-
     ostream& operator<<(ostream& os, values::hash const& hash)
     {
         os << '{';

--- a/lib/src/runtime/values/type.cc
+++ b/lib/src/runtime/values/type.cc
@@ -293,16 +293,6 @@ namespace puppet { namespace runtime { namespace values {
         return *_types[index];
     }
 
-    size_t type_set::indirect_hasher::operator()(values::type const* type) const
-    {
-        return hash_value(*type);
-    }
-
-    bool type_set::indirect_comparer::operator()(type const* right, type const* left) const
-    {
-        return *right == *left;
-    }
-
     ostream& operator<<(ostream& os, type_set const& set)
     {
         auto count = set.size();

--- a/lib/src/runtime/values/type.cc
+++ b/lib/src/runtime/values/type.cc
@@ -33,6 +33,20 @@ namespace puppet { namespace runtime { namespace values {
         return *this;
     }
 
+    struct generalize_visitor : boost::static_visitor<type>
+    {
+        template <typename T>
+        result_type operator()(T const& type) const
+        {
+            return type.generalize();
+        }
+    };
+
+    type type::generalize() const
+    {
+        return boost::apply_visitor(generalize_visitor{}, _value);
+    }
+
     struct is_instance_visitor : boost::static_visitor<bool>
     {
         is_instance_visitor(values::value const& value, types::recursion_guard& guard) :

--- a/lib/tests/fixtures/compiler/evaluation/func_bad_type.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/func_bad_type.baseline
@@ -1,5 +1,5 @@
 Notice: Scope(Class[main]): peter
-Error: func_bad_type.pp:6:6: node 'test': parameter $x has expected type String but was given Integer.
+Error: func_bad_type.pp:6:6: node 'test': parameter $x has expected type String but was given Integer[5, 5].
   test(5)
        ^
   backtrace:

--- a/lib/tests/fixtures/compiler/evaluation/invalid_variant_type_alias.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/invalid_variant_type_alias.baseline
@@ -1,4 +1,4 @@
-Error: invalid_variant_type_alias.pp:1:16: node 'test': Variant[Invalid, Invalid, Invalid] does not resolve to a real type.
+Error: invalid_variant_type_alias.pp:1:16: node 'test': Variant[Invalid] does not resolve to a real type.
   type Invalid = Variant[Invalid, Invalid, Invalid]
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   backtrace:

--- a/lib/tests/fixtures/compiler/evaluation/type_aliases.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/type_aliases.baseline
@@ -1,6 +1,6 @@
 Notice: Scope(Class[main]): [1, 2, [42, 4], [[[5]]]]
 Notice: Scope(Class[main]): [1, 2, [hello, 4], [[[5, deep]]]]
-Error: type_aliases.pp:48:8: node 'test': parameter $x has expected type MixedTree (alias for Array[Variant[Mix, MixedTree]]) but was given Array[Any].
+Error: type_aliases.pp:48:8: node 'test': parameter $x has expected type MixedTree (alias for Array[Variant[Mix, MixedTree]]) but was given Array[Data, 4, 4].
   mixed( [1, 2, [hello, 4], [[[ //, deep ]]] ] )
          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   backtrace:

--- a/lib/tests/fixtures/compiler/evaluation/type_function.baseline
+++ b/lib/tests/fixtures/compiler/evaluation/type_function.baseline
@@ -1,0 +1,170 @@
+Notice: Scope(Class[main]): Integer[1, 1]
+Notice: Scope(Class[main]): Integer[1, 1]
+Notice: Scope(Class[main]): Integer
+Notice: Scope(Class[main]): Float[2, 2]
+Notice: Scope(Class[main]): Float[2, 2]
+Notice: Scope(Class[main]): Float
+Notice: Scope(Class[main]): Boolean
+Notice: Scope(Class[main]): Boolean
+Notice: Scope(Class[main]): Boolean
+Notice: Scope(Class[main]): String[6, 6]
+Notice: Scope(Class[main]): String[6, 6]
+Notice: Scope(Class[main]): String
+Notice: Scope(Class[main]): String[3, 3]
+Notice: Scope(Class[main]): String[3, 3]
+Notice: Scope(Class[main]): String
+Notice: Scope(Class[main]): Regexp[/bar/]
+Notice: Scope(Class[main]): Regexp[/bar/]
+Notice: Scope(Class[main]): Regexp[/bar/]
+Notice: Scope(Class[main]): Undef
+Notice: Scope(Class[main]): Undef
+Notice: Scope(Class[main]): Undef
+Notice: Scope(Class[main]): Default
+Notice: Scope(Class[main]): Default
+Notice: Scope(Class[main]): Default
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Integer[2, 2], Integer[3, 3]]
+Notice: Scope(Class[main]): Array[Integer[1, 3], 3, 3]
+Notice: Scope(Class[main]): Array[Integer]
+Notice: Scope(Class[main]): Struct[{foo => String[3, 3], bar => String[3, 3]}]
+Notice: Scope(Class[main]): Hash[String[3, 3], String[3, 3], 2, 2]
+Notice: Scope(Class[main]): Hash[String, String]
+Notice: Scope(Class[main]): Type[Tuple[Variant[String[1, 2], Integer[3, 4]], Regexp]]
+Notice: Scope(Class[main]): Type[Tuple[Variant[String[1, 2], Integer[3, 4]], Regexp]]
+Notice: Scope(Class[main]): Type[Tuple[Variant[String, Integer], Regexp]]
+Notice: Scope(Class[main]): Iterator[Integer[1, 3]]
+Notice: Scope(Class[main]): Iterator[Integer[1, 3]]
+Notice: Scope(Class[main]): Iterator[Integer]
+Notice: Scope(Class[main]): Iterator[Tuple[String[3, 3], Scalar]]
+Notice: Scope(Class[main]): Iterator[Tuple[String[3, 3], Scalar]]
+Notice: Scope(Class[main]): Iterator[Tuple[String, Scalar]]
+Notice: Scope(Class[main]): Type[Foo]
+Notice: Scope(Class[main]): Type[Foo]
+Notice: Scope(Class[main]): Type[Foo]
+Notice: Scope(Class[main]): Array[0, 0]
+Notice: Scope(Class[main]): Array[0, 0]
+Notice: Scope(Class[main]): Array
+Notice: Scope(Class[main]): Hash[0, 0]
+Notice: Scope(Class[main]): Hash[0, 0]
+Notice: Scope(Class[main]): Hash
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Integer[2, 2], Integer[3, 3]]
+Notice: Scope(Class[main]): Array[Integer[1, 3], 3, 3]
+Notice: Scope(Class[main]): Array[Integer]
+Notice: Scope(Class[main]): Tuple[Float[1, 1], Float[2, 2], Float[3, 3]]
+Notice: Scope(Class[main]): Array[Float[1, 3], 3, 3]
+Notice: Scope(Class[main]): Array[Float]
+Notice: Scope(Class[main]): Tuple[String[3, 3], String[3, 3], String[4, 4]]
+Notice: Scope(Class[main]): Array[String[3, 4], 3, 3]
+Notice: Scope(Class[main]): Array[String]
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Float[2, 2], Integer[3, 3]]
+Notice: Scope(Class[main]): Array[Numeric, 3, 3]
+Notice: Scope(Class[main]): Array[Numeric]
+Notice: Scope(Class[main]): Tuple[Type[Type], String[3, 3], Integer[5, 5]]
+Notice: Scope(Class[main]): Array[Any, 3, 3]
+Notice: Scope(Class[main]): Array[Any]
+Notice: Scope(Class[main]): Tuple[Tuple[Integer[1, 1]], Tuple[Integer[2, 2], Float[3, 3]], Tuple[Integer[4, 4]]]
+Notice: Scope(Class[main]): Array[Array[Numeric], 3, 3]
+Notice: Scope(Class[main]): Array[Array[Numeric]]
+Notice: Scope(Class[main]): Tuple[Array[0, 0], Hash[0, 0]]
+Notice: Scope(Class[main]): Array[Data, 2, 2]
+Notice: Scope(Class[main]): Array
+Notice: Scope(Class[main]): Tuple[Type[Class], Type[Class]]
+Notice: Scope(Class[main]): Array[Type[Class], 2, 2]
+Notice: Scope(Class[main]): Array[Type[Class]]
+Notice: Scope(Class[main]): Tuple[Type[File], Type[File]]
+Notice: Scope(Class[main]): Array[Type[File], 2, 2]
+Notice: Scope(Class[main]): Array[Type[File]]
+Notice: Scope(Class[main]): Tuple[Type[File], Type[Notify]]
+Notice: Scope(Class[main]): Array[Type[Resource], 2, 2]
+Notice: Scope(Class[main]): Array[Type[Resource]]
+Notice: Scope(Class[main]): Tuple[Type[Pattern[/foo/]], Type[Pattern[/bar/]], Type[Pattern[/foo/, /baz/, /cake/]]]
+Notice: Scope(Class[main]): Array[Type[Pattern[/foo/, /baz/, /cake/, /bar/]], 3, 3]
+Notice: Scope(Class[main]): Array[Type[Pattern[/foo/, /baz/, /cake/, /bar/]]]
+Notice: Scope(Class[main]): Tuple[Type[Enum[foo]], Type[Enum[bar]], Type[Enum[foo, baz, cake]]]
+Notice: Scope(Class[main]): Array[Type[Enum[foo, baz, cake, bar]], 3, 3]
+Notice: Scope(Class[main]): Array[Type[Enum[foo, baz, cake, bar]]]
+Notice: Scope(Class[main]): Tuple[Type[Variant[String]], Type[Variant[Integer]], Type[Variant[String, Regexp, Type]]]
+Notice: Scope(Class[main]): Array[Type[Variant[String, Regexp, Type, Integer]], 3, 3]
+Notice: Scope(Class[main]): Array[Type[Variant[String, Regexp, Type, Integer]]]
+Notice: Scope(Class[main]): Tuple[Regexp[/foo/], Regexp[/bar/], Regexp[/baz/]]
+Notice: Scope(Class[main]): Array[Regexp, 3, 3]
+Notice: Scope(Class[main]): Array[Regexp]
+Notice: Scope(Class[main]): Tuple[Type[Callable[Integer, Callable[Numeric]]], Type[Callable[Numeric, Callable[Integer]]]]
+Notice: Scope(Class[main]): Array[Type[Callable[Integer, Callable[Numeric]]], 2, 2]
+Notice: Scope(Class[main]): Array[Type[Callable[Integer, Callable[Numeric]]]]
+Notice: Scope(Class[main]): Tuple[Type[Runtime['C++', 'foo']], Type[Runtime['C++', 'bar']]]
+Notice: Scope(Class[main]): Array[Type[Runtime], 2, 2]
+Notice: Scope(Class[main]): Array[Type[Runtime]]
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Float[2, 2]]
+Notice: Scope(Class[main]): Array[Numeric, 2, 2]
+Notice: Scope(Class[main]): Array[Numeric]
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Float[2, 2], String[3, 3], Boolean, Regexp[/bar/]]
+Notice: Scope(Class[main]): Array[Scalar, 5, 5]
+Notice: Scope(Class[main]): Array[Scalar]
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Float[2, 2], String[3, 3], Boolean, Regexp[/bar/], Tuple[Integer[1, 1]], Struct[{foo => String[3, 3]}], Undef]
+Notice: Scope(Class[main]): Array[Data, 8, 8]
+Notice: Scope(Class[main]): Array
+Notice: Scope(Class[main]): Tuple[Integer[1, 1], Float[2, 2], String[3, 3], Boolean, Regexp[/bar/], Tuple[Integer[1, 1]], Struct[{foo => String[3, 3]}], Undef, Default]
+Notice: Scope(Class[main]): Array[Any, 9, 9]
+Notice: Scope(Class[main]): Array[Any]
+Notice: Scope(Class[main]): Struct[{foo => String[3, 3], bar => Integer[1, 1]}]
+Notice: Scope(Class[main]): Hash[String[3, 3], Scalar, 2, 2]
+Notice: Scope(Class[main]): Hash[String, Scalar]
+Notice: Scope(Class[main]): Hash[Variant[Integer[1, 1], Float[3, 3]], Variant[Integer[2, 2], Float[4, 4]], 2, 2]
+Notice: Scope(Class[main]): Hash[Numeric, Numeric, 2, 2]
+Notice: Scope(Class[main]): Hash[Numeric, Numeric]
+Notice: Scope(Class[main]): Hash[Boolean, String[3, 3], 2, 2]
+Notice: Scope(Class[main]): Hash[Boolean, String[3, 3], 2, 2]
+Notice: Scope(Class[main]): Hash[Boolean, String]
+Notice: Scope(Class[main]): Hash[Variant[String[3, 3], Integer[1, 1], Regexp[/bar/]], Variant[Integer[1, 1], Regexp[/two/], String[5, 5]], 3, 3]
+Notice: Scope(Class[main]): Hash[Scalar, Scalar, 3, 3]
+Notice: Scope(Class[main]): Hash[Scalar, Scalar]
+{
+  "name": "test",
+  "version": 123456789
+  "environment": "production",
+  "resources": [
+    {
+      "type": "Stage",
+      "title": "main",
+      "tags": [
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "settings",
+      "tags": [
+        "class",
+        "settings",
+        "stage"
+      ],
+      "exported": false
+    },
+    {
+      "type": "Class",
+      "title": "main",
+      "tags": [
+        "class",
+        "main",
+        "stage"
+      ],
+      "exported": false
+    }
+  ],
+  "edges": [
+    {
+      "source": "Stage[main]",
+      "target": "Class[settings]"
+    },
+    {
+      "source": "Stage[main]",
+      "target": "Class[main]"
+    }
+  ],
+  "classes": [
+    "settings",
+    "main"
+  ]
+}
+

--- a/lib/tests/fixtures/compiler/evaluation/type_function.pp
+++ b/lib/tests/fixtures/compiler/evaluation/type_function.pp
@@ -1,0 +1,65 @@
+function display_type($x) {
+    notice type($x, detailed)
+    notice type($x, reduced)
+    notice type($x, generalized)
+
+    if type($x) != type($x, detailed) {
+        fail "unexpected default behavior of the type function: `${type($x)}` vs. `${type($x, detailed)}`"
+    }
+}
+
+type Foo = Variant[Foo, Array[Foo], Integer]
+
+# Basic value tests
+display_type(1)
+display_type(2.0)
+display_type(true)
+display_type(falses)
+display_type('foo')
+display_type(/bar/)
+display_type(undef)
+display_type(default)
+display_type([1, 2, 3])
+display_type({ foo => bar, bar => baz })
+display_type(Tuple[Variant[String[1, 2], Integer[3, 4]], Regexp])
+display_type([1, 2, 3].reverse_each)
+display_type({foo => 1, bar => /foo/ }.reverse_each)
+display_type(Foo)
+
+# Empty array and hash
+display_type([])
+display_type({})
+
+# Common type tests
+display_type([1, 2, 3])
+display_type([1.0, 2.0, 3.0])
+display_type([foo, bar, cake])
+display_type([1, 2.0, 3])
+display_type([Type, foo, 5])
+display_type([[1], [2, 3.0], [4]])
+display_type([[], {}])
+display_type([Class, Class])
+display_type([File, File])
+display_type([File, Notify])
+display_type([Pattern[foo], Pattern[bar], Pattern[foo, baz, cake]])
+display_type([Enum[foo], Enum[bar], Enum[foo, baz, cake]])
+display_type([Variant[String], Variant[Integer], Variant[String, Regexp, Type]])
+display_type([/foo/, /bar/, /baz/])
+display_type([Callable[Integer, Callable[Numeric]], Callable[Numeric, Callable[Integer]]])
+display_type([Runtime['C++', 'foo'], Runtime['C++', 'bar']])
+display_type([1, 2.0])
+display_type([1, 2.0, foo, true, /bar/])
+display_type([1, 2.0, foo, true, /bar/, [1], { foo => bar }, undef])
+display_type([1, 2.0, foo, true, /bar/, [1], { foo => bar }, undef, default])
+
+# Hashes with all string keys
+display_type({ foo => bar, bar => 1 })
+
+# Hashes with non-string keys
+display_type({ 1 => 2, 3.0 => 4.0 })
+
+# Hashes without string keys that unwrap to a single key and value type
+display_type({ true => foo, false => bar })
+
+# Hashes that infer variants for key and value type
+display_type({ foo => 1, 1 => /two/, /bar/ => three })


### PR DESCRIPTION
This implements type inference in a similar fashion to the Ruby implementation and the 4.4 `type` function that takes a value and returns its inferred type.