### PR TITLE
(maint) Add codecov.yml for code coverage settings.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,10 @@
+coverage:
+  ignore:
+  - vendor/.*
+  - lib/tests/.*
+  status:
+    patch: false
+  round: up
+  range: "50...85"
+comment: off
+


### PR DESCRIPTION
codecov.io, the site we use for CI coverage, has migrated settings to a YAML
file.  This commit restores the settings that were previously being set via the
website.