### PR TITLE
(NPUP-37) Allow the environment to have private functions.

### DIFF
--- a/lib/src/compiler/evaluation/functions/descriptor.cc
+++ b/lib/src/compiler/evaluation/functions/descriptor.cc
@@ -55,6 +55,17 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
             // Ensure the caller is allowed to call this function if it is private
             if (_expression->is_private && _expression->tree && context.name().tree &&
                 _expression->tree->module() != context.name().tree->module()) {
+                if (!_expression->tree->module()) {
+                    throw evaluation_exception(
+                        (boost::format("function '%1%' (declared at %2%:%3%) is private to the environment.") %
+                         context.name() %
+                         _expression->tree->path() %
+                         _expression->begin.line()
+                        ).str(),
+                        context.name(),
+                        evaluation_context.backtrace()
+                    );
+                }
                 throw evaluation_exception(
                     (boost::format("function '%1%' (declared at %2%:%3%) is private to module '%4%'.") %
                      context.name() %

--- a/lib/src/compiler/scanner.cc
+++ b/lib/src/compiler/scanner.cc
@@ -452,17 +452,6 @@ namespace puppet { namespace compiler {
             );
         }
 
-        // Ensure private functions have an associated module
-        if (expression.is_private && expression.tree && !expression.tree->module()) {
-            throw parse_exception(
-                (boost::format("function '%1%' cannot be declared private because it is not contained in a module.") %
-                 expression.name
-                ).str(),
-                expression.name.begin,
-                expression.name.end
-            );
-        }
-
         scope_helper scope{ _scopes };
 
         // Scan the parameters


### PR DESCRIPTION
This commit allows private functions in the environment where previously there
was a requirement that private functions only be defined in modules.

Now if a private environment function is called, an appropriate error message
is displayed to the user.