### PR TITLE
(maint) Add buildstats badge to the README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 Puppet Compiler in C++
 ======================
 
-[![Build Status](https://travis-ci.org/puppetlabs/puppetcpp.svg?branch=master)](https://travis-ci.org/puppetlabs/puppetcpp) [![codecov](https://codecov.io/gh/puppetlabs/puppetcpp/branch/master/graph/badge.svg)](https://codecov.io/gh/puppetlabs/puppetcpp)
+[![Build Status](https://travis-ci.org/puppetlabs/puppetcpp.svg?branch=master)](https://travis-ci.org/puppetlabs/puppetcpp) [![Code Coverage](https://codecov.io/gh/puppetlabs/puppetcpp/branch/master/graph/badge.svg)](https://codecov.io/gh/puppetlabs/puppetcpp)
+
+[![Build History](https://buildstats.info/travisci/chart/puppetlabs/puppetcpp)](https://travis-ci.org/puppetlabs/puppetcpp)
 
 This is a (very early) attempt to write a Puppet 4.x compiler in C++14.
 


### PR DESCRIPTION
Adding a buildstats.info badge to the README to display a historical view of
build statuses.