### PR TITLE
(maint) Fixes to README and install procedure.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Expression evaluator status:
 * [x] local scope
 * [x] node scope
 * [x] string interpolation
-* [ ] Puppet type aliases
+* [x] Puppet type aliases
 * [x] custom functions written in Puppet
 * [ ] custom functions written in Ruby
 * [ ] custom types written in Puppet
@@ -155,11 +155,11 @@ Puppet functions implemented:
 * [ ] slice
 * [x] split
 * [ ] sprintf
-* [ ] step
+* [x] step
 * [x] tag
 * [x] tagged
 * [ ] template
-* [ ] type
+* [x] type
 * [x] versioncmp
 * [x] warning
 * [x] with
@@ -220,7 +220,7 @@ Also consider using [Ninja](https://ninja-build.org/) as a replacement for GNU M
 
 Then use `ninja` instead of `make` in the examples below.
 
-**Note: tracking precompiled header changes with Nina is [currently unsupported in CMake](https://cmake.org/Bug/view.php?id=13234) so it is recommended to set `DISABLE_PCH=1`.** 
+**Note: tracking precompiled header changes with ninja is [currently unsupported in CMake](https://cmake.org/Bug/view.php?id=13234) so it is recommended to add `-DDISABLE_PCH=1` when running cmake.**
 
 Build
 -----

--- a/docker/puppetcpp/Dockerfile
+++ b/docker/puppetcpp/Dockerfile
@@ -33,8 +33,7 @@ RUN apk add --no-cache make cmake gcc g++ boost-dev curl-dev libedit-dev git && 
     cd /tmp/puppetcpp && \
     cmake . && \
     make -j 4 && \
-    cp bin/puppetcpp /usr/bin/ && \
-    cp lib/libpuppet.so.0.1.0 /usr/lib/ && \
+    make install && \
     cd && \
     rm -rf /tmp/puppetcpp && \
     mkdir -p /etc/puppetlabs/code/environments/production && \

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -200,7 +200,7 @@ if (Editline_FOUND)
     target_link_libraries(puppet ${Editline_LIBRARY})
 endif()
 
-install(TARGETS puppet DESTINATION lib)
+install(TARGETS puppet DESTINATION lib${LIB_SUFFIX})
 
 cotire(generate_static_lexer)
 cotire(puppet)


### PR DESCRIPTION
Updating the README to fix spelling mistake and check off features that have
been implemented.

Also fixing the install target to include `LIB_SUFFIX` so that the library is
installed into the correct location on platforms that have a lib64.