### PR TITLE
(NPUP-44) Validate function, application, and type alias names.

### DIFF
--- a/lib/include/puppet/compiler/ast/visitors/validation.hpp
+++ b/lib/include/puppet/compiler/ast/visitors/validation.hpp
@@ -101,7 +101,6 @@ namespace puppet { namespace compiler { namespace ast { namespace visitors {
         void operator()(basic_query_expression const& expression);
         void operator()(attribute_query const& expression);
 
-        bool is_class_name_valid(std::string const& name) const;
         void validate_parameters(std::vector<parameter> const& parameters, bool is_resource = false, bool pass_by_hash = false);
         void validate_parameter_name(parameter const& parameter, bool is_resource_parameter) const;
         location current_location() const;

--- a/lib/tests/fixtures/compiler/parser/illegal_app_name.baseline
+++ b/lib/tests/fixtures/compiler/parser/illegal_app_name.baseline
@@ -1,0 +1,3 @@
+Error: illegal_app_name.pp:1:13: '::foo' is not a valid name for an application.
+  application ::foo {
+              ^~~~~

--- a/lib/tests/fixtures/compiler/parser/illegal_app_name.pp
+++ b/lib/tests/fixtures/compiler/parser/illegal_app_name.pp
@@ -1,0 +1,3 @@
+application ::foo {
+
+}

--- a/lib/tests/fixtures/compiler/parser/illegal_func_name.baseline
+++ b/lib/tests/fixtures/compiler/parser/illegal_func_name.baseline
@@ -1,0 +1,3 @@
+Error: illegal_func_name.pp:1:10: '::foo' is not a valid name for a function.
+  function ::foo() {
+           ^~~~~

--- a/lib/tests/fixtures/compiler/parser/illegal_func_name.pp
+++ b/lib/tests/fixtures/compiler/parser/illegal_func_name.pp
@@ -1,0 +1,3 @@
+function ::foo() {
+
+}

--- a/lib/tests/fixtures/compiler/parser/illegal_type_alias_name.baseline
+++ b/lib/tests/fixtures/compiler/parser/illegal_type_alias_name.baseline
@@ -1,0 +1,3 @@
+Error: illegal_type_alias_name.pp:1:6: '::Foo' is not a valid name for a type alias.
+  type ::Foo = Integer
+       ^~~~~

--- a/lib/tests/fixtures/compiler/parser/illegal_type_alias_name.pp
+++ b/lib/tests/fixtures/compiler/parser/illegal_type_alias_name.pp
@@ -1,0 +1,1 @@
+type ::Foo = Integer


### PR DESCRIPTION
This commit adds a validation check for functions, applications, and alias
names so that they may not start with '::'.