### PR TITLE
(maint) Fix unnecessary copy of return values.

### DIFF
--- a/lib/src/compiler/evaluation/functions/each.cc
+++ b/lib/src/compiler/evaluation/functions/each.cc
@@ -44,7 +44,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                         }
                         // Check for control transfer and break out of the loop
                         if (result.is_transfer()) {
-                            transfer = result;
+                            transfer = rvalue_cast(result);
                             return false;
                         }
                         return true;

--- a/lib/src/compiler/evaluation/functions/filter.cc
+++ b/lib/src/compiler/evaluation/functions/filter.cc
@@ -34,7 +34,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                     }
                     // Check for control transfer and break out of the loop
                     if (filtered.is_transfer()) {
-                        transfer = filtered;
+                        transfer = rvalue_cast(filtered);
                         return false;
                     }
                     if (filtered.is_true()) {
@@ -91,7 +91,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                         }
                         // Check for control transfer and break out of the loop
                         if (filtered.is_transfer()) {
-                            transfer = filtered;
+                            transfer = rvalue_cast(filtered);
                             return false;
                         }
                         if (filtered.is_true()) {

--- a/lib/src/compiler/evaluation/functions/map.cc
+++ b/lib/src/compiler/evaluation/functions/map.cc
@@ -44,7 +44,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                         }
                         // Check for control transfer and break out of the loop
                         if (replacement.is_transfer()) {
-                            transfer = replacement;
+                            transfer = rvalue_cast(replacement);
                             return false;
                         }
                         result.emplace_back(rvalue_cast(replacement));

--- a/lib/src/compiler/evaluation/functions/reduce.cc
+++ b/lib/src/compiler/evaluation/functions/reduce.cc
@@ -49,7 +49,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                         }
                         // Check for control transfer and break out of the loop
                         if (result.is_transfer()) {
-                            transfer = result;
+                            transfer = rvalue_cast(result);
                             return false;
                         }
                         memo.emplace(rvalue_cast(result));

--- a/lib/src/compiler/evaluation/functions/reverse_each.cc
+++ b/lib/src/compiler/evaluation/functions/reverse_each.cc
@@ -47,7 +47,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                 }
                 // Check for control transfer and break out of the loop
                 if (result.is_transfer()) {
-                    transfer = result;
+                    transfer = rvalue_cast(result);
                     return false;
                 }
                 return true;

--- a/lib/src/compiler/evaluation/functions/step.cc
+++ b/lib/src/compiler/evaluation/functions/step.cc
@@ -47,7 +47,7 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
                 }
                 // Check for control transfer and break out of the loop
                 if (result.is_transfer()) {
-                    transfer = result;
+                    transfer = rvalue_cast(result);
                     return false;
                 }
                 return true;

--- a/lib/tests/fixtures/compiler/parser/return_in_interpolation.baseline
+++ b/lib/tests/fixtures/compiler/parser/return_in_interpolation.baseline
@@ -1,3 +1,3 @@
-Error: return_in_interpolation.pp:2:5: syntax error: expected '{' but found interpolated string.
+Error: return_in_interpolation.pp:2:42: return statement cannot be used inside an interpolated string.
   "${ 'foo'.each |$x| { if $x == 'o' { return } $x } }"
-  ^
+                                       ^~~~~~

--- a/lib/tests/fixtures/compiler/parser/return_in_interpolation.pp
+++ b/lib/tests/fixtures/compiler/parser/return_in_interpolation.pp
@@ -1,3 +1,3 @@
-function foo()
+function foo() {
     "${ 'foo'.each |$x| { if $x == 'o' { return } $x } }"
 }


### PR DESCRIPTION
This commit fixes an unnecessary copy of return values from within the
iterating functions.

Also fixed was a missing brace that caused an incorrect test baseline for
testing using a return statement in an interpolated string.  The test and
baseline have been updated.