### PR TITLE
Minor changes to support consumers of the C API.

### DIFF
--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -217,6 +217,7 @@ if (Editline_FOUND)
 endif()
 
 install(TARGETS puppet DESTINATION lib${LIB_SUFFIX})
+install(DIRECTORY include/ DESTINATION include)
 
 cotire(generate_static_lexer)
 cotire(puppet)

--- a/lib/src/compiler/evaluation/functions/alert.cc
+++ b/lib/src/compiler/evaluation/functions/alert.cc
@@ -17,7 +17,11 @@ namespace puppet { namespace compiler { namespace evaluation { namespace functio
 
         // Log the message
         if (logger.would_log(level)) {
-            logger.log(level, (boost::format("%1%: %2%") % current % message).str());
+            if (!current.resource()) {
+                logger.log(level, message);
+            } else {
+                logger.log(level, (boost::format("%1%: %2%") % current % message).str());
+            }
         }
         return message;
     }


### PR DESCRIPTION
This PR installs headers with the install target and removes a meaningless prefix from logged messages when a log function is called from a scope without an associated resource (i.e. when not compiling for a catalog).